### PR TITLE
Update Nucleus

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Michael Heilmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Primordial Machine
+Copyright (c) 2018 Michael Heilmann
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Nucleus
-Nucleus is basic C project with CMake support.
-Nucleus works for Windows and Linux.
+
+Nucleus is a C cross-platform utility library for Windows, Linux, and OS X.
+Nucleus is made available publicly under the
+[MIT license](https://github.com/primordialmachine/nucleus/blob/master/LICENSE.md) 
+on
+[Github](https://github.com/primordialmachine/nucleus).
 
 ## Building the demo (Windows)
 Visual Studio is currently *still* supported.
@@ -11,13 +15,13 @@ Change the directory to the directory of this file.
 
 Enter
 ```
-cmake CMakeLists.txt -a Win32
+cmake -a Win32 CMakeLists.txt
 ```
 to generate the project files for Win32.
 
 Enter
 ```
-cmake CMakeLists.txt -a x64
+cmake -a x64 CMakeLists.txt
 ```
 to generate the project files for x64.
 
@@ -95,6 +99,8 @@ The Array-functions do not only exist for convenience, but also for safety: Thes
 
 - [Nucleus_allocateMemory](documentation/Nucleus_allocateMemory.md)
 - [Nucleus_allocateArrayMemory](documentation/Nucleus_allocateArrayMemory.md)
+- [Nucleus_reallocateMemory](documentation/Nucleus_reallocateMemory.md)
+- [Nucleus_reallocateArrayMemory](documentation/Nucleus_reallocateArrayMemory.md)
 - [Nucleus_deallocateMemory](documentation/Nucleus_deallocateMemory.md)
 - [Nucleus_copyMemory](documentation/Nucleus_copyMemory.md)
 - [Nucleus_copyArrayMemory](documentation/Nucleus_copyArrayMemory.md)

--- a/documentation/Nucleus_allocateArrayMemory.md
+++ b/documentation/Nucleus_allocateArrayMemory.md
@@ -1,5 +1,5 @@
 # `Nucleus_allocateMemory`
-*Allocate a memory block of a specified size.*
+*Allocate a memory block.*
 
 ## C Specification
 ```

--- a/documentation/Nucleus_allocateMemory.md
+++ b/documentation/Nucleus_allocateMemory.md
@@ -1,5 +1,5 @@
 # `Nucleus_allocateMemory`
-*Allocate a memory block of a specified size.*
+*Allocate a memory block.*
 
 ## C Specification
 ```

--- a/documentation/Nucleus_copyArrayMemory.md
+++ b/documentation/Nucleus_copyArrayMemory.md
@@ -1,4 +1,4 @@
-# `Nucleus_copyMemory`
+# `Nucleus_copyArrayMemory`
 *Copy contents of a memory block to another memory block.*
 
 ## C Specification
@@ -22,7 +22,8 @@ Nucleus_copyMemory
 This function copies contents of a memory block to another memory block.
 
 If this function succeeds, `n` Bytes were copied from the memory block pointed to by `q` to the memory block pointed to by `p`.
-Otherwise a non-zero status code is returned. In particular, if `p` or `q` is a null pointer `Nucleus_Status_InvalidArgument` is returned.
+This function fails if and only if `p` or `q` is a null pointer or `n * m` would overflow. `Nucleus_Status_InvalidArgument`
+is returned in the former case, `Nucleus_Status_Overflow` is returned in the latter case.
 The source and the target memory blocks may or may not overlap.
 
 The number of Bytes (to copy) is specified in terms of array semantics i.e. `n` should be thought of as the array size, in elements, and `m` as the element size, in Bytes.

--- a/documentation/Nucleus_copyMemory.md
+++ b/documentation/Nucleus_copyMemory.md
@@ -21,7 +21,7 @@ Nucleus_copyMemory
 This function copies contents of a memory block to another memory block.
 
 If this function succeeds, `n` Bytes were copied from the memory block pointed to by `q` to the memory block pointed to by `p`.
-Otherwise a non-zero status code is returned. In particular, if `p` or `q` is a null pointer `Nucleus_Status_InvalidArgument` is returned.
+This function fails if and only if `p` or `q` is a null pointers. `Nucleus_Status_InvalidArgument` is returned in that case.
 The source and the target memory blocks may or may not overlap.
 
 ## Requirements

--- a/documentation/Nucleus_reallocateArrayMemory.md
+++ b/documentation/Nucleus_reallocateArrayMemory.md
@@ -1,0 +1,41 @@
+# `Nucleus_reallocateArrayMemory`
+*Reallocate a memory block.*
+
+## C Specification
+```
+Nucleus_Status
+Nucleus_reallocateArrayMemory
+    (
+        void **p,
+        size_t n,
+        size_t m
+    );
+```
+
+## Parameters
+- `p` a pointer to a `void *` variable
+- `n`, `m` the product of @a n and @a m is the size, in Bytes, of the memory block to allocate. Note that @a 0 is a valid size.
+
+## Description
+This function reallocates a memory block.
+
+If this function succeeds, then this function conceptually performed the following tasks:
+The function conceptually allocates a new memory block of size `n * m` and copies `min(n * m,k)` Bytes from the old
+memory block pointed to by `*p` of size `k` to the new memory block. The old memory block is then deallocated.
+The address of the new memory block is is assigned to `*p` and `Nucleus_Status_Success` is returned.
+
+This function fails if and only if one or more of the following conditions are met:
+- `p` or `*p` is a null pointer
+- `n * m` would overflow
+- the allocation of the new memory block failed
+
+Under the first condition `Nucleus_InvalidArgument` is returned,
+under the second condition `Nucleus_Overflow` is returned, and
+under the third condition `Nucleus_AllocationFailed`` is returned.
+
+## Requirements
+
+|                      | Windows                  | Linux                     |
+|----------------------|--------------------------|---------------------------|
+| *Header*             | `Nucleus/Memory.h`       | `Nucleus/Memory.h`        |
+| *Static library*     | `Nucleus.Library.lib`    | `libNucleus.Library.a`    |

--- a/documentation/Nucleus_reallocateMemory.md
+++ b/documentation/Nucleus_reallocateMemory.md
@@ -1,0 +1,40 @@
+# `Nucleus_reallocateMemory`
+*Reallocate a memory block.*
+
+
+## C Specification
+```
+Nucleus_Status
+Nucleus_reallocateMemory
+    (
+        void **p,
+        size_t n
+    );
+```
+
+## Parameters
+- `p` a pointer to a `void *` variable
+- `n` the size, in Bytes, of the memory block to allocate. Note that `0` is a valid size.
+
+## Description
+This function reallocates a memory block.
+
+If this function succeeds, then this function conceptually performed the following tasks:
+The function conceptually allocates a new memory block of size `n` and copies `min(n, k)` Bytes from the old
+memory block pointed to by `*p` of size `k` to the new memory block. The old memory block is then deallocated.
+The address of the new memory block is is assigned to `*p` and `Nucleus_Status_Success` is returned.
+
+This function fails if and only if one or more of the following conditions are met:
+- `p` or `*p` is a null pointer or
+- the allocation of the new memory block failed
+
+
+Under the former condition `Nucleus_InvalidArgument` is returned and
+under the latter condition `Nucleus_AllocationFailed` is returned.
+
+## Requirements
+
+|                      | Windows                  | Linux                     |
+|----------------------|--------------------------|---------------------------|
+| *Header*             | `Nucleus/Memory.h`       | `Nucleus/Memory.h`        |
+| *Static library*     | `Nucleus.Library.lib`    | `libNucleus.Library.a`    |

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -23,8 +23,11 @@ file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
+# Find and configure inlay files.
+file(GLOB_RECURSE INLAY_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.i")
+set_source_files_properties(${INLAY_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Define and configure the library.
-add_library(Nucleus.Library STATIC ${SOURCE_FILES} ${HEADER_FILES})
+add_library(Nucleus.Library STATIC ${SOURCE_FILES} ${HEADER_FILES} ${INLAY_FILES})
 target_include_directories(Nucleus.Library PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 target_include_directories(Nucleus.Library INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 

--- a/library/src/Nucleus/Collections.h
+++ b/library/src/Nucleus/Collections.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "Nucleus/Status.h"
+#include <stdbool.h> // For bool, true, false.
+
+
+
+
+/// @brief Macro unconditionally casting a @a (Nucleus_LockFunction) or derived pointer into a @a (Nucleus_LockFunction) pointer.
+/// @param pointer the pointer
+#define NUCLEUS_LOCKFUNCTION(pointer) ((Nucleus_LockFunction *)(pointer))
+
+/// @brief A "lock" callback.
+/// @param object a pointer to an opaque object, the object to be locked
+/// @remark The caller must ensure that @a is passed a proper value.
+typedef void Nucleus_LockFunction(void *object);
+
+
+
+
+/// @brief Macro unconditionally casting a @a (Nucleus_UnlockFunction) or derived pointer into a @a (Nucleus_UnlockFunction) pointer.
+/// @param pointer the pointer
+#define NUCLEUS_UNLOCKFUNCTION(pointer) ((Nucleus_UnlockFunction *)(pointer))
+
+/// @brief An "unlock" callback.
+/// @param object a pointer to an opaque object, the object to be unlocked
+/// @remark The caller must ensure that @a is passed a proper value.
+typedef void Nucleus_UnlockFunction(void *object);
+
+
+
+
+/// @brief Macro unconditionally casting a @a (Nucleus_HashFunction) or derived pointer into a @a (Nucleus_HashFunction) pointer.
+/// @param pointer the pointer
+#define NUCLEUS_HASHFUNCTION(pointer) ((Nucleus_HashFunction *)(pointer))
+
+/// @brief A "hash" callback.
+/// @param a pointer to the object to be hashed.
+typedef Nucleus_Status Nucleus_HashFunction(void *, unsigned int *);
+
+
+
+
+/// @brief Macro unconditionally casting a @a (Nucleus_EqualToFunction) or derived pointer into a @a (Nucleus_EqualToFunction) pointer.
+/// @param pointer the pointer
+#define NUCLEUS_EQUALTOFUNCTION(pointer) ((Nucleus_EqualToFunction *)(pointer))
+
+/// @brief An "equalTo" callback.
+/// @param left, right pointers to the objects to be compared
+/// @param [out] equal a pointer to a @a bool variable
+typedef Nucleus_Status Nucleus_EqualToFunction(void *, void *, bool *);

--- a/library/src/Nucleus/CommandLine.h
+++ b/library/src/Nucleus/CommandLine.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "Nucleus/CommandLine/CommandLine.h"

--- a/library/src/Nucleus/CommandLine/CommandLine-private.c.i
+++ b/library/src/Nucleus/CommandLine/CommandLine-private.c.i
@@ -1,0 +1,361 @@
+#include "Nucleus/CommandLine/CommandLine-private.h.i"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if defined(Nucleus_Compiler_MSVC)
+static char *
+strndup
+    (
+        const char *s,
+        size_t n
+    )
+{
+    char *result;
+    size_t len = strlen(s);
+
+    if (n < len)
+        len = n;
+
+    result = (char *)malloc(len + 1);
+    if (!result)
+        return 0;
+
+    result[len] = '\0';
+    return (char *)memcpy(result, s, len);
+}
+#endif
+
+Nucleus_NonNull() static Nucleus_Status
+parseArgument
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *argument
+    )
+{
+    Nucleus_Status status;
+    if (argument[0] == '-')
+    {
+        argument++;
+        // an option argument
+        if (*argument == '-')
+        {
+            argument++;
+        }
+        else if (*argument == '\0')
+        {
+            fprintf(stderr, "invalid command-line argument, expected name\n");
+            return Nucleus_Status_InvalidArgument;
+        }
+        const char *p = argument;
+        while (*p != '\0' && *p != '=')
+        {
+            p++;
+        }
+        if (p == argument)
+        {
+            fprintf(stderr, "invalid command-line argument, expeted name\n");
+            return Nucleus_Status_InvalidArgument;
+        }
+        char *name = strndup(argument, p - argument);
+        if (!name) { fprintf(stderr, "<internal error>\n"); return Nucleus_Status_AllocationFailed; }
+        Nucleus_CommandLine_Option *option;
+        status = Nucleus_CommandLine_Command_getOption(command, name, &option);
+        if (status && status != Nucleus_Status_NotExists)
+        { free(name); return status; }
+        if (status == Nucleus_Status_NotExists)
+            if (Nucleus_CommandLine_Command_addOption(command, name, &option))
+            { free(name); return status; }
+        free(name);
+        argument = p;
+        if (*argument == '\0') return Nucleus_Status_Success;
+        else if (*argument == '=') argument++;
+        p = argument;
+        while (*p != '\0')
+        {
+            p++;
+        }
+        char *value = strndup(argument, p - argument);
+        if (!value) { fprintf(stderr, "<internal error>\n"); return Nucleus_Status_AllocationFailed; }
+        status = Nucleus_CommandLine_Option_addParameter(option, value);
+        if (status)
+        { free(value); fprintf(stderr, "<internal error>\n"); return status; }
+        free(value);
+    }
+    else
+    {
+        // a command parameter argument
+        status = Nucleus_CommandLine_Command_addParameter(command, argument);
+        if (status) { return status; }
+    }
+    return Nucleus_Status_Success;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Nucleus_NonNull() static Nucleus_Status
+hashFunction
+    (
+        const char *p,
+        unsigned int *hv
+    )
+{ return Nucleus_hashMemory(p, strlen(p), hv); }
+
+Nucleus_NonNull() static Nucleus_Status
+equalToFunction
+    (
+        const char *p,
+        const char *q,
+        bool *r
+    )
+{
+    if (!p || !q || !r) return Nucleus_Status_InvalidArgument;
+    *r = !strcmp(p, q);
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static Nucleus_Status
+OptionSet_initialize
+    (
+        OptionSet *optionSet
+    )
+{
+    Nucleus_Status status = Nucleus_DynamicPointerHashMap_initialize(&optionSet->hashMap,
+                                                                     16,
+                                                                     NULL,
+                                                                     NULL,
+                                                                     NUCLEUS_HASHFUNCTION(&hashFunction),
+                                                                     NUCLEUS_EQUALTOFUNCTION(&equalToFunction),
+                                                                     NULL,
+                                                                     NUCLEUS_UNLOCKFUNCTION(&destroyOption));
+    if (status) return status;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static void
+OptionSet_uninitialize
+    (
+        OptionSet *optionSet
+    )
+{ Nucleus_DynamicPointerHashMap_uninitialize(&optionSet->hashMap); }
+
+Nucleus_NonNull() static Nucleus_Status
+OptionSet_add
+    (
+        OptionSet *optionSet,
+        Nucleus_CommandLine_Option *option
+    )
+{
+    if (!optionSet || !option) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status = Nucleus_DynamicPointerHashMap_set(&optionSet->hashMap, option->name, option, false);
+    if (status == Nucleus_Status_Exists)
+    { return status; }
+    else if (status)
+    { return status; }
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static Nucleus_Status
+OptionSet_find
+    (
+        OptionSet *optionSet,
+        const char *optionName,
+        Nucleus_CommandLine_Option **option
+    )
+{
+    if (!optionSet || !optionName || !option) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status = Nucleus_DynamicPointerHashMap_get(&optionSet->hashMap, (void *)optionName, (void **)option);
+    if (status == Nucleus_Status_NotExists)
+    { return status; }
+    else if (status)
+    { return status; }
+    return Nucleus_Status_Success;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Nucleus_NonNull() static Nucleus_Status
+ParameterList_initialize
+    (
+        ParameterList *parameterList
+    )
+{
+    if (!parameterList) return Nucleus_Status_InvalidArgument;
+    return Nucleus_DynamicPointerArray_initialize(&parameterList->array, 8,
+                                                  NULL,
+                                                  (void (*)(void *))&destroyParameter);
+}
+
+Nucleus_NonNull() static void
+ParameterList_uninitialize
+    (
+        ParameterList *parameterList
+    )
+{ Nucleus_DynamicPointerArray_uninitialize(&parameterList->array); }
+
+Nucleus_NonNull() static Nucleus_Status
+ParameterList_append
+    (
+        ParameterList *parameterList,
+        Nucleus_CommandLine_Parameter *parameter
+    )
+{ return Nucleus_DynamicPointerArray_append(&parameterList->array, parameter); }
+
+Nucleus_NonNull() static Nucleus_Status
+ParameterList_getSize
+    (
+        ParameterList *parameterList,
+        size_t *size
+    )
+{
+    if (!parameterList) return Nucleus_Status_InvalidArgument;
+    return Nucleus_DynamicPointerArray_getSize(&parameterList->array, size);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Nucleus_NonNull() static Nucleus_Status
+createOption
+    (
+        Nucleus_CommandLine_Option **option,
+        const char *optionName
+    )
+{
+    if (!option || !optionName) return Nucleus_Status_InvalidArgument;
+    Nucleus_CommandLine_Option *self = malloc(sizeof(Nucleus_CommandLine_Option));
+    if (!self) return Nucleus_Status_AllocationFailed;
+    Nucleus_Status status = ParameterList_initialize(&self->parameterList);
+    if (status) { free(self); return status; }
+    self->name = _strdup(optionName);
+    if (!self->name)
+    {
+        ParameterList_uninitialize(&self->parameterList);
+        free(self);
+        return Nucleus_Status_AllocationFailed;
+    }
+    *option = self;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static void
+destroyOption
+    (
+        Nucleus_CommandLine_Option *option
+    )
+{
+    ParameterList_uninitialize(&option->parameterList);
+    if (option->name)
+    {
+        free(option->name);
+        option->name = NULL;
+    }
+    free(option);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Nucleus_NonNull() static Nucleus_Status
+createParameter
+    (
+        Nucleus_CommandLine_Parameter **parameter,
+        const char *parameterValue
+    )
+{
+    if (!parameter || !parameterValue) return Nucleus_Status_InvalidArgument;
+    Nucleus_CommandLine_Parameter *self = malloc(sizeof(Nucleus_CommandLine_Parameter));
+    if (!self) return Nucleus_Status_AllocationFailed;
+    self->value = _strdup(parameterValue);
+    if (!self->value)
+    {
+        free(self);
+        return Nucleus_Status_AllocationFailed;
+    }
+    *parameter = self;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static void
+uninitializeParameter
+    (
+        Nucleus_CommandLine_Parameter *parameter
+    )
+{
+    if (parameter->value)
+    {
+        free(parameter->value);
+        parameter->value = NULL;
+    }
+}
+
+Nucleus_NonNull() static void
+destroyParameter
+    (
+        Nucleus_CommandLine_Parameter *parameter
+    )
+{
+    uninitializeParameter(parameter);
+    free(parameter);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Nucleus_NonNull() static Nucleus_Status
+initializeCommand
+    (
+        Nucleus_CommandLine_Command *command
+    )
+{
+    if (!command) return Nucleus_Status_InvalidArgument;
+
+    Nucleus_Status status;
+
+    status = ParameterList_initialize(&command->parameterList);
+    if (status) return status;
+
+    status = OptionSet_initialize(&command->optionSet);
+    if (status)
+    {
+        ParameterList_uninitialize(&command->parameterList);
+        return status;
+    }
+
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static void
+uninitializeCommand
+    (
+        Nucleus_CommandLine_Command *command
+    )
+{
+    ParameterList_uninitialize(&command->parameterList);
+    OptionSet_uninitialize(&command->optionSet);
+}
+
+Nucleus_NonNull() static Nucleus_Status
+createCommand
+    (
+        Nucleus_CommandLine_Command **command
+    )
+{
+    if (!command) return Nucleus_Status_InvalidArgument;
+    Nucleus_CommandLine_Command *o = malloc(sizeof(Nucleus_CommandLine_Command));
+    if (!o) return Nucleus_Status_AllocationFailed;
+    Nucleus_Status status = initializeCommand(o);
+    if (status)
+    {
+        free(o);
+        return status;
+    }
+    *command = o;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static void
+destroyCommand
+    (
+        Nucleus_CommandLine_Command *command
+    )
+{
+    uninitializeCommand(command);
+    free(command);
+}

--- a/library/src/Nucleus/CommandLine/CommandLine-private.h.i
+++ b/library/src/Nucleus/CommandLine/CommandLine-private.h.i
@@ -1,0 +1,185 @@
+#pragma once
+
+#include "Nucleus/CommandLine/CommandLine.h"
+#include "Nucleus/Memory.h"
+#include "Nucleus/DynamicPointerArray.h"
+#include "Nucleus/DynamicPointerHashMap.h"
+#include <malloc.h> // For malloc() and free().
+#include <string.h> // For strcmp() and strdup().
+#include <stdio.h>  // For fprintf().
+
+#if defined(Nucleus_Compiler_MSVC)
+static char *
+strndup
+    (
+        const char *s,
+        size_t n
+    );
+#else
+#define _strdup strdup
+#endif
+
+Nucleus_NonNull() static Nucleus_Status
+parseArgument
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *argument
+    );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+typedef struct ParameterList
+{ Nucleus_DynamicPointerArray array; } ParameterList;
+
+Nucleus_NonNull() static Nucleus_Status
+ParameterList_initialize
+    (
+        ParameterList *parameterList
+    );
+
+Nucleus_NonNull() static void
+ParameterList_uninitialize
+    (
+        ParameterList *parameterList
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+ParameterList_append
+    (
+        ParameterList *parameterList,
+        Nucleus_CommandLine_Parameter *parameter
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+ParameterList_getSize
+    (
+        ParameterList *parameterList,
+        size_t *size
+    );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+typedef struct OptionSet
+{ Nucleus_DynamicPointerHashMap hashMap; } OptionSet;
+
+Nucleus_NonNull() static Nucleus_Status
+hashFunction
+    (
+        const char *p,
+        unsigned int *hv
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+equalToFunction
+    (
+        const char *p,
+        const char *q,
+        bool *r
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+OptionSet_initialize
+    (
+        OptionSet *optionSet
+    );
+
+Nucleus_NonNull() static void
+OptionSet_uninitialize
+    (
+        OptionSet *optionSet
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+OptionSet_add
+    (
+        OptionSet *optionSet,
+        Nucleus_CommandLine_Option *option
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+OptionSet_find
+    (
+        OptionSet *optionSet,
+        const char *optionName,
+        Nucleus_CommandLine_Option **option
+    );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Nucleus_CommandLine_Command
+{
+    OptionSet optionSet;
+    ParameterList parameterList;
+}; // struct Nucleus_CommandLine_Command
+
+
+Nucleus_NonNull() static Nucleus_Status
+initializeCommand
+    (
+        Nucleus_CommandLine_Command *command
+    );
+
+Nucleus_NonNull() static void
+uninitializeCommand
+    (
+        Nucleus_CommandLine_Command *command
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+createCommand
+    (
+        Nucleus_CommandLine_Command **command
+    );
+
+Nucleus_NonNull() static void
+destroyCommand
+    (
+        Nucleus_CommandLine_Command *command
+    );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Nucleus_CommandLine_Option
+{
+    char *name;
+    ParameterList parameterList;
+}; // struct Nucleus_CommandLine_Option
+
+Nucleus_NonNull() static Nucleus_Status
+createOption
+    (
+        Nucleus_CommandLine_Option **option,
+        const char *optionName
+    );
+
+Nucleus_NonNull() static void
+destroyOption
+    (
+        Nucleus_CommandLine_Option *option
+    );
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Nucleus_CommandLine_Parameter
+{
+    char *value;
+}; // struct Nucleus_CommandLine_Parameter
+
+Nucleus_NonNull() static Nucleus_Status
+createParameter
+    (
+        Nucleus_CommandLine_Parameter **parameter,
+        const char *parameterValue
+    );
+
+Nucleus_NonNull() static void
+uninitializeParameter
+    (
+        Nucleus_CommandLine_Parameter *parameter
+    );
+
+Nucleus_NonNull() static void
+destroyParameter
+    (
+        Nucleus_CommandLine_Parameter *parameter
+    );

--- a/library/src/Nucleus/CommandLine/CommandLine.c
+++ b/library/src/Nucleus/CommandLine/CommandLine.c
@@ -1,0 +1,169 @@
+#include "Nucleus/CommandLine/CommandLine-private.c.i"
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_parse
+    (
+        Nucleus_CommandLine_Command **command,
+        int numberOfArguments,
+        char **arguments
+    )
+{
+    if (!command || !arguments) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status;
+    Nucleus_CommandLine_Command *command_;
+    status = Nucleus_CommandLine_Command_create(&command_);
+    if (status) return status;
+
+    // Add command parameters, command options, and option parameters.
+    for (int argumentIndex = 1; argumentIndex < numberOfArguments; ++argumentIndex)
+    {
+        const char *argument = arguments[argumentIndex];
+        status = parseArgument(command_, argument);
+        if (status) { Nucleus_CommandLine_Command_destroy(command_); return status; }
+    }
+    *command = command_;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_create
+    (
+        Nucleus_CommandLine_Command **command
+    )
+{ return createCommand(command); }
+
+Nucleus_NonNull() void
+Nucleus_CommandLine_Command_destroy
+    (
+        Nucleus_CommandLine_Command *command
+    )
+{ destroyCommand(command); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_getParameterCount
+    (
+        Nucleus_CommandLine_Command *command,
+        size_t *parameterCount
+    )
+{
+    if (!command) return Nucleus_Status_InvalidArgument;
+    return ParameterList_getSize(&command->parameterList, parameterCount);
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Option_getParameterCount
+    (
+        Nucleus_CommandLine_Option *option,
+        size_t *parameterCount
+    )
+{
+    if (!option) return Nucleus_Status_InvalidArgument;
+    return ParameterList_getSize(&option->parameterList, parameterCount);
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_getParameter
+    (
+        Nucleus_CommandLine_Command *command,
+        size_t index,
+        Nucleus_CommandLine_Parameter **parameter
+    )
+{
+    if (!command) return Nucleus_Status_InvalidArgument;
+    return Nucleus_DynamicPointerArray_at(&command->parameterList.array, index, (void **)parameter);
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Option_getParameter
+    (
+        Nucleus_CommandLine_Option *option,
+        size_t index,
+        Nucleus_CommandLine_Parameter **parameter)
+{
+    if (!option) return Nucleus_Status_InvalidArgument;
+    return Nucleus_DynamicPointerArray_at(&option->parameterList.array, index, (void **)parameter);
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_addParameter
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *parameterValue
+    )
+{
+    if (!command || !parameterValue) return Nucleus_Status_InvalidArgument;
+    Nucleus_CommandLine_Parameter *parameter = malloc(sizeof(Nucleus_CommandLine_Parameter));
+    if (!parameter) return Nucleus_Status_AllocationFailed;
+    parameter->value = _strdup(parameterValue);
+    if (!parameter->value)
+    {
+        free(parameter);
+        return Nucleus_Status_AllocationFailed;
+    }
+    Nucleus_Status status = ParameterList_append(&(command->parameterList), parameter);
+    if (status) { destroyParameter(parameter); return status; }
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_addOption
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *optionName,
+        Nucleus_CommandLine_Option **option
+    )
+{
+    if (!command || !optionName || !option) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status;
+    Nucleus_CommandLine_Option *option_;
+
+    status = createOption(&option_, optionName);
+    if (status) return status;
+
+    status = OptionSet_add(&command->optionSet, option_);
+    if (status) { destroyOption(option_); return status; }
+    *option = option_;
+
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_getOption
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *optionName,
+        Nucleus_CommandLine_Option **option
+    )
+{ return OptionSet_find(&command->optionSet, optionName, option); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Option_addParameter
+    (
+        Nucleus_CommandLine_Option *option,
+        const char *parameterValue
+    )
+{
+    if (!option || !parameterValue) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status;
+
+    Nucleus_CommandLine_Parameter *parameter;
+    status = createParameter(&parameter, parameterValue);
+    if (status) return status;
+
+    status = ParameterList_append(&(option->parameterList), parameter);
+    if (status) { destroyParameter(parameter); return status; }
+
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Parameter_getValue
+    (
+        const Nucleus_CommandLine_Parameter *parameter,
+        const char **parameterValue
+    )
+{
+    if (!parameter || !parameterValue) return Nucleus_Status_InvalidArgument;
+    *parameterValue = parameter->value;
+    return Nucleus_Status_Success;
+}

--- a/library/src/Nucleus/CommandLine/CommandLine.h
+++ b/library/src/Nucleus/CommandLine/CommandLine.h
@@ -1,0 +1,143 @@
+// A command is split into an array of strings named arguments.
+// Argument 0 is (normally) the command name, argument 1, the first element following the command, and so on.
+//
+// - An "option" is a documented type of argument modifying the behaviour of a command
+// e.g. "-v" or "--verbose" are options.
+//
+// - A "parameter" is an argument that provides information to either the command or one of its options,
+// e.g. in "-o file", "file" is the parameter of the "-o" option.
+#pragma once
+
+#include "Nucleus/Annotations.h"
+#include "Nucleus/Status.h"
+#include <stddef.h> // For size_t.
+
+typedef struct Nucleus_CommandLine_Parameter Nucleus_CommandLine_Parameter;
+typedef struct Nucleus_CommandLine_Option Nucleus_CommandLine_Option;
+typedef struct Nucleus_CommandLine_Command Nucleus_CommandLine_Command;
+
+/// @brief Create a @a (Nucleus_CommandLine_Command) object.
+/// @param [out] command a pointer to a @a (Nucleus_CommandLine_Command) variable
+/// @param numberOfArguments the number of command-line arguments
+/// @param arguments a pointer to an array of @a numberOfArguments pointers to command-line arguments
+/// @return #Nucleus_Status_Success on success, one of the following status codes on failure:
+/// - #Nucleus_Status_InvalidArgument @a command is a null pointer
+/// - #Nucleus_Status_AllocationFailed an allocation failed
+/// @post @a (*command) was assigned a pointer to a @a (Nucleus_CommandLine_Command) object
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_parse
+    (
+        Nucleus_CommandLine_Command **command,
+        int numberOfArguments,
+        char **arguments
+    );
+
+/// @brief Create a @a (Nucleus_CommandLine_Command) object.
+/// @param [out] command a pointer to a @a (Nucleus_CommandLine_Command) variable
+/// @return #Nucleus_Status_Success on success, one of the following status codes on failure:
+/// - #Nucleus_Status_InvalidArgument @a command is a null pointer
+/// - #Nucleus_Status_AllocationFailed an allocation failed
+/// @post @a (*command) was assigned a pointer to a @a (Nucleus_CommandLine_Command) object
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_create
+    (
+        Nucleus_CommandLine_Command **command
+    );
+
+/// @brief Destroy a @a (Nucleus_CommandLine_Command) object.
+/// @param command a pointer to the @a (Nucleus_CommandLine_Command) object
+Nucleus_NonNull() void
+Nucleus_CommandLine_Command_destroy
+    (
+        Nucleus_CommandLine_Command *command
+    );
+
+/// @brief Get the number of parameters of a @a (Nucleus_CommandLine_Command) object.
+/// @param command a pointer to the @a (Nucleus_CommandLine_Command) object
+/// @return #Nucleus_Status_Success on success, one of the folowing status codes is returned on failure:
+/// - #Nucleus_Status_InvalidArgument @a command or @a parameterCount is a null pointer
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_getParameterCount
+    (
+        Nucleus_CommandLine_Command *command,
+        size_t *parameterCount
+    );
+
+/// @brief Get the number of parameters of a @a (Nucleus_CommandLine_Option) object.
+/// @param command a pointer to the @a (Nucleus_CommandLine_Option) object
+/// @return #Nucleus_Status_Success on success, one of the folowing status codes is returned on failure:
+/// - #Nucleus_Status_InvalidArgument @a command or @a parameterCount is a null pointer
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Option_getParameterCount
+    (
+        Nucleus_CommandLine_Option *option,
+        size_t *parameterCount
+    );
+
+// i-th parameter
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_getParameter
+    (
+        Nucleus_CommandLine_Command *command,
+        size_t index,
+        Nucleus_CommandLine_Parameter **parameter
+    );
+
+// i-th parameter
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Option_getParameter
+    (
+        Nucleus_CommandLine_Option *option,
+        size_t index,
+        Nucleus_CommandLine_Parameter **parameter
+    );
+
+/// @brief Add a parameter to a @a (Nucleus_CommandLine_Command) object.
+/// @param command a pointer to the @a (Nucleus_CommandLine_Command) object
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_addParameter
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *parameterValue
+    );
+
+/// @brief Add a parameter to a @a (Nucleus_CommandLine_Option) object.
+/// @param option a pointer to the @a (Nucleus_CommandLine_Option) object
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Option_addParameter
+    (
+        Nucleus_CommandLine_Option *option,
+        const char *parameterValue
+    );
+
+/// Add an option to a command.
+/// @param command a pointer to the @a (Nucleus_CommandLine_Command) object
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_addOption
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *optionName,
+        Nucleus_CommandLine_Option **opt
+     );
+
+// Find option: Return NULL if option was not found.
+/// @param command a pointer to the @a (Nucleus_CommandLine_Command) object
+/// @param optionName a pointer to constant C string, the option name
+/// @param [out] option a pointer to a @a (Nucleus_CommandLine_Option) variable
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Command_getOption
+    (
+        Nucleus_CommandLine_Command *command,
+        const char *optionName,
+        Nucleus_CommandLine_Option **option
+    );
+
+/// @brief Get the value of a @a (Nucleus_CommandLine_Parameter) object.
+/// @param parameter a pointer to the @a (Nucleus_CommandLine_Parameter) object
+/// @param [out] parameterValue a pointer to a @a (const char *) variable
+Nucleus_NonNull() Nucleus_Status
+Nucleus_CommandLine_Parameter_getValue
+    (
+        const Nucleus_CommandLine_Parameter *parameter,
+        const char **parameterValue
+    );

--- a/library/src/Nucleus/CommandLine/Nucleus_CommandLine.md
+++ b/library/src/Nucleus/CommandLine/Nucleus_CommandLine.md
@@ -1,0 +1,6 @@
+A command is split into an array of strings named arguments.
+Argument 0 is (normally) the command name, argument 1, the first element following the command, and so on.
+
+- An "option" is a documented type of argument modifying the behaviour of a command e.g. "-v" or "--verbose" are options.
+
+- A "parameter" is an argument that provides information to either the command or one of its options, e.g. in "-o file", "file" is the parameter of the "-o" option.

--- a/library/src/Nucleus/DynamicByteArray.c
+++ b/library/src/Nucleus/DynamicByteArray.c
@@ -29,6 +29,7 @@ Nucleus_DynamicByteArray_uninitialize
     dynamicByteArray->array = NULL;
 }
 
+// TODO: Use Nucleus_reallocate(Array)Memory.
 Nucleus_NonNull() Nucleus_Status
 Nucleus_DynamicByteArray_ensureFreeCapacity
     (
@@ -54,6 +55,7 @@ Nucleus_DynamicByteArray_ensureFreeCapacity
         Nucleus_deallocateMemory(oldArray);
         dynamicByteArray->capacity = newCapacity;
     }
+    return Nucleus_Status_Success;
 }
 
 Nucleus_NonNull() Nucleus_Status

--- a/library/src/Nucleus/DynamicByteArray.h
+++ b/library/src/Nucleus/DynamicByteArray.h
@@ -1,19 +1,20 @@
+// Copyright (c) Michael Heilmann 2018
 #pragma once
 
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
 #include <stddef.h> // For size_t.
 
-/// @brief A dynamically resizing Byte buffer.
+/// @brief A dynamic array of Bytes.
 typedef struct Nucleus_DynamicByteArray Nucleus_DynamicByteArray;
 
 struct Nucleus_DynamicByteArray
 {
-    /// @brief A pointer to an array of @a capacity Bytes.
+    /// @brief A pointer to an array of @a capacity @a (char) elements.
     char *array;
-    /// @brief The size, in Bytes, of the array pointed to by @a array.
+    /// @brief The capacity, in elements, of the array pointed to by @a array.
     size_t capacity;
-    /// @brief The number of Bytes in this string buffer. 
+    /// @brief The number of elements in this array. 
     size_t size;
 }; // struct Nucleus_DynamicByteArray
 

--- a/library/src/Nucleus/DynamicPointerArray.c
+++ b/library/src/Nucleus/DynamicPointerArray.c
@@ -1,0 +1,204 @@
+// Copyright (c) Michael Heilmann 2018
+#include "Nucleus/DynamicPointerArray.h"
+
+#include "Nucleus/Memory.h"
+
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_initialize
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t initialCapacity,
+        Nucleus_LockFunction *lockFunction,
+        Nucleus_UnlockFunction *unlockFunction
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray)) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status = Nucleus_allocateArrayMemory((void **)&dynamicPointerArray->elements,
+                                                        initialCapacity,
+                                                        sizeof(void *));
+    if (Nucleus_Unlikely(status)) return status;
+    dynamicPointerArray->size = 0;
+    dynamicPointerArray->capacity = initialCapacity;
+    dynamicPointerArray->lockFunction = lockFunction;
+    dynamicPointerArray->unlockFunction = unlockFunction;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_uninitialize
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray
+    )
+{
+    if (dynamicPointerArray->unlockFunction)
+    {
+        Nucleus_UnlockFunction *unlockFunction = dynamicPointerArray->unlockFunction;
+        while (dynamicPointerArray->size > 0)
+        {
+            unlockFunction(dynamicPointerArray->elements[dynamicPointerArray->size - 1]);
+            dynamicPointerArray->size--;
+        }
+
+    }
+    else
+    {
+        dynamicPointerArray->size = 0;
+    }
+    Nucleus_deallocateMemory(dynamicPointerArray->elements);
+    dynamicPointerArray->elements = NULL;
+    dynamicPointerArray->capacity = 0;
+    return Nucleus_Status_Success;
+}
+
+// TODO: Use Nucleus_reallocate(Array)Memory.
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_ensureFreeCapacity
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t requiredFreeCapacity
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray)) return Nucleus_Status_InvalidArgument;
+    size_t availableFreeCapacity = dynamicPointerArray->capacity - dynamicPointerArray->size;
+    if (availableFreeCapacity < requiredFreeCapacity)
+    {
+        size_t additionalCapacity = requiredFreeCapacity - availableFreeCapacity;
+        size_t oldCapacity = dynamicPointerArray->capacity;
+        size_t newCapacity = oldCapacity + additionalCapacity;
+        void **oldElements = dynamicPointerArray->elements;
+        void **newElements;
+        Nucleus_Status status = Nucleus_allocateArrayMemory((void **)&newElements,
+                                                            newCapacity,
+                                                            sizeof(void *));
+        if (Nucleus_Unlikely(status)) return status;
+        Nucleus_copyArrayMemory(newElements, oldElements, oldCapacity, sizeof(void *));
+        dynamicPointerArray->elements = newElements;
+        Nucleus_deallocateMemory(oldElements);
+        dynamicPointerArray->capacity = newCapacity;
+    }
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_append
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        void *pointer
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray)) return Nucleus_Status_InvalidArgument;
+    return Nucleus_DynamicPointerArray_insert(dynamicPointerArray, pointer, dynamicPointerArray->size);
+}
+
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_prepend
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        void *pointer
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray)) return Nucleus_Status_InvalidArgument;
+    return Nucleus_DynamicPointerArray_insert(dynamicPointerArray, pointer, 0);
+}
+
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_insert
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        void *pointer,
+        size_t index
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray)) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(index > dynamicPointerArray->size)) return Nucleus_Status_IndexOutOfBounds;
+    Nucleus_Status status;
+    status = Nucleus_DynamicPointerArray_ensureFreeCapacity(dynamicPointerArray, 1);
+    if (Nucleus_Unlikely(status)) return status;
+    if (dynamicPointerArray->lockFunction)
+    {
+        dynamicPointerArray->lockFunction(pointer);
+    }
+    Nucleus_copyMemory(dynamicPointerArray->elements + index + 1, dynamicPointerArray->elements + index,
+                       sizeof(void *));
+
+    dynamicPointerArray->elements[index] = pointer;
+    dynamicPointerArray->size++;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_at
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t index,
+        void **pointer
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray || !pointer)) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(index >= dynamicPointerArray->size)) return Nucleus_Status_IndexOutOfBounds;
+    *pointer = dynamicPointerArray->elements[index];
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_getSize
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t *size
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray || !size)) return Nucleus_Status_InvalidArgument;
+    *size = dynamicPointerArray->size;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_getCapacity
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t *capacity
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray || !capacity)) return Nucleus_Status_InvalidArgument;
+    *capacity = dynamicPointerArray->capacity;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_getFreeCapacity
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t *freeCapacity
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray || !freeCapacity)) return Nucleus_Status_InvalidArgument;
+    *freeCapacity = dynamicPointerArray->capacity - dynamicPointerArray->size;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_clear
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerArray))
+    {
+        return Nucleus_Status_InvalidArgument;
+    }
+    if (dynamicPointerArray->unlockFunction)
+    {
+        Nucleus_UnlockFunction *unlockFunction = dynamicPointerArray->unlockFunction;
+        while (dynamicPointerArray->size > 0)
+        {
+            unlockFunction(dynamicPointerArray->elements[dynamicPointerArray->size - 1]);
+            dynamicPointerArray->size--;
+        }
+
+    }
+    else
+    {
+        dynamicPointerArray->size = 0;
+    }
+    return Nucleus_Status_Success;
+}

--- a/library/src/Nucleus/DynamicPointerArray.h
+++ b/library/src/Nucleus/DynamicPointerArray.h
@@ -1,0 +1,121 @@
+// Copyright (c) Michael Heilmann 2018
+#pragma once
+
+#include "Nucleus/Annotations.h"
+#include "Nucleus/Collections.h"
+#include <stddef.h> // For size_t.
+
+/// @brief A dynamic array of pointers.
+typedef struct Nucleus_DynamicPointerArray Nucleus_DynamicPointerArray;
+
+struct Nucleus_DynamicPointerArray
+{
+    /// @brief A pointer to an array of @a capacity @a (void *) elements.
+    void **elements;
+    /// @brief The capacity, in elements, of the array pointed to by @a array.
+    size_t capacity;
+    /// @brief The number of elements in this array. 
+    size_t size;
+    /// @brief A pointer to the @a Nucleus_LockFunction function or a null pointer.
+    Nucleus_LockFunction *lockFunction;
+    /// @brief A pointer to the @a Nucleus_UnlockFunction function or  a null pointer.
+    Nucleus_UnlockFunction *unlockFunction;
+}; // struct Nucleus_DynamicPointerArray
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_initialize.md
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_initialize
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t initialCapacity,
+        Nucleus_LockFunction *lockFunction,
+        Nucleus_UnlockFunction *unlockFunction
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_uninitialize.md
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_uninitialize
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray
+    );
+
+/// @brief Ensure the free capacity of a @a (Nucleus_DynamicPointerArray) is greater than or equal a required free capacity.
+/// @param dynamicPointerArray a pointer to an initialized @a (Nucleus_DynamicPointerArray) object
+/// @param requiredFreeCapacity the required free capacity
+/// @details The free capacity of the @a (Nucleus_DynamicPointerArray) object pointed to by @a (dynamicPointerArray) is greater than or
+/// equal to the required free capacity @a requiredFreeCapacity on success and #Nucleus_Status_Success is returned.
+/// On error, one of the non-zero status codes below is returned:
+/// - `Nucleus_Status_InvalidArgument`: ``dynamicPointerArray` is a null pointer
+/// - `Nucleus_Status_AllocationFailed`: an allocation failed
+/// - `Nucleus_Status_Overflow`: the required free capacity `requiredFreeCapacity` is too big
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_ensureFreeCapacity
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t requiredFreeCapacity
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_append.md
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_append
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        void *pointer
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_prepend.md
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_prepend
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        void *pointer
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_insert.md
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerArray_insert
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        void *pointer,
+        size_t index
+    );
+
+/// @ingroup dl
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_at
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t index,
+        void **pointer
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_getSize.md
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_getSize
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t *size
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_getCapacity.md
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_getCapacity
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t *capacity
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_getFreeCapacity.md
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_getFreeCapacity
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray,
+        size_t *freeCapacity
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerArray_clear.md
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerArray_clear
+    (
+        Nucleus_DynamicPointerArray *dynamicPointerArray
+    );

--- a/library/src/Nucleus/DynamicPointerHashMap-private.c.i
+++ b/library/src/Nucleus/DynamicPointerHashMap-private.c.i
@@ -1,0 +1,51 @@
+// Copyright (c) Michael Heilmann 2018
+#include "Nucleus/DynamicPointerHashMap-private.h.i"
+
+Nucleus_NonNull() static Nucleus_Status 
+getPosition
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        void *key,
+        Position *position
+    )
+{
+    if (!dynamicPointerHashMap) return Nucleus_Status_InvalidArgument;
+    dynamicPointerHashMap->hashKeyFunction(key, &position->hashValue);
+    position->hashIndex = position->hashValue % dynamicPointerHashMap->capacity;
+    position->node = NULL;
+    for (Nucleus_DynamicPointerHashMap_Node *node = dynamicPointerHashMap->buckets[position->hashIndex];
+         NULL != node; node = node->next)
+    {
+        bool equalTo;
+        dynamicPointerHashMap->keyEqualToKeyFunction(key, node->key, &equalTo);
+        if (equalTo)
+        {
+            position->node = node;
+            break;
+        }
+    }
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static void
+clear
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap
+    )
+{
+    for (size_t i = 0, n = dynamicPointerHashMap->capacity; i < n; ++i)
+    {
+        Nucleus_DynamicPointerHashMap_Node **bucket = &(dynamicPointerHashMap->buckets[i]);
+        while (*bucket)
+        {
+            Nucleus_DynamicPointerHashMap_Node *node = *bucket; *bucket = node->next;
+            if (dynamicPointerHashMap->unlockKeyFunction)
+                dynamicPointerHashMap->unlockKeyFunction(node->key);
+            if (dynamicPointerHashMap->unlockValueFunction)
+                dynamicPointerHashMap->unlockValueFunction(node->value);
+            dynamicPointerHashMap->size--;
+            node->next = dynamicPointerHashMap->unused;
+            dynamicPointerHashMap->unused = node;
+        }
+    }
+}

--- a/library/src/Nucleus/DynamicPointerHashMap-private.h.i
+++ b/library/src/Nucleus/DynamicPointerHashMap-private.h.i
@@ -1,0 +1,34 @@
+// Copyright (c) Michael Heilmann 2018
+#pragma once
+
+#include "Nucleus/DynamicPointerHashMap.h"
+#include "Nucleus/Memory.h"
+
+struct Nucleus_DynamicPointerHashMap_Node
+{
+    Nucleus_DynamicPointerHashMap_Node *next;
+    void *key;
+    size_t hashValue;
+    void *value;
+}; // struct Nucleus_DynamicPointerHashMap_Node
+
+typedef struct Position
+{
+    Nucleus_DynamicPointerHashMap_Node *node; // Pointer to the colliding node or a null pointer.
+    unsigned int hashValue; // The hash value.
+    unsigned int hashIndex; // The hash index.
+} Position;
+
+Nucleus_NonNull() static Nucleus_Status 
+getPosition
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        void *key,
+        Position *position
+    );
+
+Nucleus_NonNull() static void
+clear
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap
+    );

--- a/library/src/Nucleus/DynamicPointerHashMap.c
+++ b/library/src/Nucleus/DynamicPointerHashMap.c
@@ -1,0 +1,145 @@
+// Copyright (c) Michael Heilmann 2018
+#include "Nucleus/DynamicPointerHashMap-private.c.i"
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerHashMap_initialize
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        size_t initialCapacity,
+        Nucleus_LockFunction *lockKeyFunction,
+        Nucleus_UnlockFunction *unlockKeyFunction,
+        Nucleus_HashFunction *hashKeyFunction,
+        Nucleus_EqualToFunction *keyEqualToKeyFunction,
+        Nucleus_LockFunction *lockValueFunction,
+        Nucleus_UnlockFunction *unlockValueFunction
+    )
+{
+    if (Nucleus_Unlikely(!dynamicPointerHashMap)) return Nucleus_Status_InvalidArgument;
+    
+    initialCapacity = initialCapacity > 0 ? initialCapacity : 1;
+    
+    Nucleus_Status status = Nucleus_allocateArrayMemory((void **)&dynamicPointerHashMap->buckets,
+                                                        initialCapacity,
+                                                        sizeof(Nucleus_DynamicPointerHashMap_Node *));
+    if (Nucleus_Unlikely(status)) return status;
+    for (size_t i = 0, n = initialCapacity; i < n; ++i)
+    {
+        dynamicPointerHashMap->buckets[i] = NULL;
+    }
+
+    dynamicPointerHashMap->size = 0;
+    dynamicPointerHashMap->capacity = initialCapacity;
+
+    dynamicPointerHashMap->unused = NULL;
+
+    dynamicPointerHashMap->lockKeyFunction = lockKeyFunction;
+    dynamicPointerHashMap->unlockKeyFunction = unlockKeyFunction;
+    dynamicPointerHashMap->hashKeyFunction = hashKeyFunction;
+    dynamicPointerHashMap->keyEqualToKeyFunction = keyEqualToKeyFunction;
+    dynamicPointerHashMap->lockValueFunction = lockValueFunction;
+    dynamicPointerHashMap->unlockValueFunction = unlockValueFunction;
+    
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() void
+Nucleus_DynamicPointerHashMap_uninitialize
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap
+    )
+{
+    clear(dynamicPointerHashMap);
+
+    Nucleus_deallocateMemory(dynamicPointerHashMap->buckets);
+    dynamicPointerHashMap->buckets = NULL;
+    dynamicPointerHashMap->capacity = 0;
+
+    while(dynamicPointerHashMap->unused)
+    {
+        Nucleus_DynamicPointerHashMap_Node *node = dynamicPointerHashMap->unused;
+        dynamicPointerHashMap->unused = node->next;
+        Nucleus_deallocateMemory(node);
+    }
+}
+
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerHashMap_set
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        void *key,
+        void *value,
+        bool replace
+    )
+{
+    Position position;
+    Nucleus_Status status = getPosition(dynamicPointerHashMap, key, &position);
+    if (status) return status;
+    if (position.node)
+    {
+        if (replace)
+        {
+            if (dynamicPointerHashMap->lockKeyFunction)
+                dynamicPointerHashMap->lockKeyFunction(key);
+            if (dynamicPointerHashMap->lockValueFunction)
+                dynamicPointerHashMap->lockValueFunction(value);
+            if (dynamicPointerHashMap->unlockKeyFunction)
+                dynamicPointerHashMap->unlockKeyFunction(position.node->key);
+            if (dynamicPointerHashMap->unlockValueFunction)
+                dynamicPointerHashMap->unlockValueFunction(position.node->value);
+            position.node->key = key;
+            position.node->value = value;
+            return Nucleus_Status_Success;
+        }
+        else
+        {
+            return Nucleus_Status_Exists;
+        }
+    }
+    Nucleus_DynamicPointerHashMap_Node *node = NULL;
+    if (dynamicPointerHashMap->unused)
+    {
+        node = dynamicPointerHashMap->unused; dynamicPointerHashMap->unused = node->next;
+    }
+    else
+    {
+        status = Nucleus_allocateMemory((void **)&node, sizeof(Nucleus_DynamicPointerHashMap_Node));
+        if (status) return status;
+    }
+    if (dynamicPointerHashMap->lockKeyFunction)
+        dynamicPointerHashMap->lockKeyFunction(key);
+    if (dynamicPointerHashMap->lockValueFunction)
+        dynamicPointerHashMap->lockValueFunction(value);
+    node->key = key;
+    node->value = value;
+    node->next = dynamicPointerHashMap->buckets[position.hashIndex];
+    dynamicPointerHashMap->buckets[position.hashIndex] = node;
+    dynamicPointerHashMap->size++;
+    /// TODO: Invoke Optimize which resizes the hash map. If resizing fails, there is no error.
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerHashMap_get
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        void *key,
+        void **value
+    )
+{
+    Position position;
+    Nucleus_Status status = getPosition(dynamicPointerHashMap, key, &position);
+    if (status) return status;
+    if (position.node) { *value = position.node->value; return Nucleus_Status_Success; }
+    else return Nucleus_Status_NotExists;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerHashMap_clear
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap
+    )
+{
+    clear(dynamicPointerHashMap);
+    return Nucleus_Status_Success;
+}
+

--- a/library/src/Nucleus/DynamicPointerHashMap.h
+++ b/library/src/Nucleus/DynamicPointerHashMap.h
@@ -1,0 +1,69 @@
+// Copyright (c) Michael Heilmann 2018
+#pragma once
+
+#include "Nucleus/Annotations.h"
+#include <stddef.h> // For size_t.
+#include "Nucleus/Collections.h"
+
+typedef struct Nucleus_DynamicPointerHashMap_Node Nucleus_DynamicPointerHashMap_Node;
+
+typedef struct Nucleus_DynamicPointerHashMap Nucleus_DynamicPointerHashMap;
+struct Nucleus_DynamicPointerHashMap
+{
+    Nucleus_DynamicPointerHashMap_Node **buckets;
+    size_t size, capacity;
+    Nucleus_DynamicPointerHashMap_Node *unused;
+
+    Nucleus_LockFunction *lockKeyFunction;
+    Nucleus_UnlockFunction *unlockKeyFunction;
+    Nucleus_HashFunction *hashKeyFunction;
+    Nucleus_EqualToFunction *keyEqualToKeyFunction;
+
+    Nucleus_LockFunction *lockValueFunction;
+    Nucleus_UnlockFunction *unlockValueFunction;
+
+}; // struct Nucleus_DynamicPointerHashMap
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerHashMap_initialize.md
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerHashMap_initialize
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        size_t initialCapacity,
+        Nucleus_LockFunction *lockKeyFunction,
+        Nucleus_UnlockFunction *unlockKeyFunction,
+        Nucleus_HashFunction *hashKeyFunction,
+        Nucleus_EqualToFunction *keyEqualToKeyFunction,
+        Nucleus_LockFunction *lockValueFunction,
+        Nucleus_UnlockFunction *unlockValueFunction
+    );
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_DynamicPointerHashMap_uninitialize.md
+Nucleus_NonNull() void
+Nucleus_DynamicPointerHashMap_uninitialize
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap
+    );
+
+Nucleus_NonNull(1) Nucleus_Status
+Nucleus_DynamicPointerHashMap_set
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        void *key,
+        void *value,
+        bool replace
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerHashMap_get
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap,
+        void *key,
+        void **value
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DynamicPointerHashMap_clear
+    (
+        Nucleus_DynamicPointerHashMap *dynamicPointerHashMap
+    );

--- a/library/src/Nucleus/Memory.h
+++ b/library/src/Nucleus/Memory.h
@@ -15,6 +15,7 @@ Nucleus_allocateMemory
         size_t n
     );
 
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_reallocateMemory.md
 Nucleus_NoError() Nucleus_NonNull(1) Nucleus_Status
 Nucleus_reallocateMemory
     (
@@ -31,6 +32,7 @@ Nucleus_allocateArrayMemory
         size_t m
     );
 
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_reallocateArrayMemory.md
 Nucleus_NoError() Nucleus_NonNull(1) Nucleus_Status
 Nucleus_reallocateArrayMemory
     (


### PR DESCRIPTION
Update Nucleus

- The documentation of
  * Nucleus_copyMemory and
  * Nucleus_copyArrayMemory
  was improved: It is documented now that these functions fail if
  and only if certain conditions occur and that wether or not these
  conditions occur is completely determined by the callee. The
  return values of the functions precisely specified now.
- Documentation for
  * Nucleus_reallocateMemory and
  * Nucleus_reallocateArrayMemory
  was added
- buildsystem: Dependencies to inlay files were made explicit in
  CMake files
- Fix Windows build instructions in README.md
- Nucleus switched to MIT License
- Nucleus_DynamicByteArray was fixed
- Nucleus_DynamicPointerArray and Nucleus_DynamicPointerHashMap were
  added
- Nucleus_CommandLine was added