### PR TITLE
Update Nucleus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,20 +11,36 @@ message("building Nucleus")
 include(CTest)
 enable_testing()
 
+if (MSVC OR MINGW)
+  if (NOT DEFINED With-Static-Runtime)
+    set(With-Static-Runtime ON CACHE BOOL
+        "enable/disable compilation with static runtime. \
+         ON enables compilation with static runtime, OFF disables compilation with static runtime. \
+         Initial value is ON. \
+         Only available under MSVC and MINGW" FORCE)
+  endif()
+endif()
+
 if (NOT DEFINED With-Optimizations)
   set(With-Optimizations ON CACHE BOOL
-      "enable/disable compilation with optimizations. ON enables compilation with optimizations, OFF disables compilation with optimizations. Initial value is ON." FORCE)
+      "enable/disable compilation with optimizations. \
+       ON enables compilation with optimizations, OFF disables compilation with optimizations. \
+       Initial value is ON." FORCE)
 endif()
 
 if (NOT DEFINED With-Debug-Information)
   set(With-Debug-Information OFF CACHE BOOL
-      "enable/disable compilation with debug information. ON enables compilation with debug information, OFF disables compilation with debug information. Initial value is OFF." FORCE)
+      "enable/disable compilation with debug information. \
+       ON enables compilation with debug information, OFF disables compilation with debug information. \
+       Initial value is OFF." FORCE)
 endif()
 
 # Enable/disable compilation and execution of unit tests.
 # The value of this option can be set from the command-line by -Didlib-with-tests=(ON|OFF).
 option(Nucleus-With-Tests
-       "enable/disable compilation and execution of unit tests. ON enables compilation and execution of unit tests, OFF disables compilation and execution of unit tests. Initial value is ON."
+       "enable/disable compilation and execution of unit tests. \
+        ON enables compilation and execution of unit tests, OFF disables compilation and execution of unit tests. \
+        Initial value is ON."
        ON)
 
 # The output directories.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nucleus is made available publicly under the
 on
 [Github](https://github.com/primordialmachine/nucleus).
 
-## Building the demo (Windows)
+## Building under Visual Studio 2017/Windows
 Visual Studio is currently *still* supported.
 
 Open the console.
@@ -34,7 +34,17 @@ ctest -C <configuration>
 
 ```configuration``` is one of `Debug`, `Release`, `MinSizeRel`, `RelWithDebInfo`.
 
-## Building the demo (Linux and Cygwin)
+### Compilation options (Visual Studio)
+For Visual Studio builds, the option `With-Static-Runtime=(ON|OFF)` is supported.
+`ON` enables static linking with the C runtime, `OFF` enables dynamic linking with the runtime.
+The default value is `ON`.
+
+For example, to enable dynamic linking with the runtime enter
+```
+cmake -DWith-Static-Runtime=OFF CMakeLists.txt
+```
+
+## Building under Linux and Cygwin
 Open the console.
 
 Change the directory to the directory of this file.
@@ -106,6 +116,8 @@ The Array-functions do not only exist for convenience, but also for safety: Thes
 - [Nucleus_deallocateMemory](documentation/Nucleus_deallocateMemory.md)
 - [Nucleus_copyMemory](documentation/Nucleus_copyMemory.md)
 - [Nucleus_copyArrayMemory](documentation/Nucleus_copyArrayMemory.md)
+- [Nucleus_cloneMemory](documentation/Nucleus_cloneMemory.md)
+- [Nucleus_cloneArrayMemory](documentation/Nucleus_cloneArrayMemory.md)
 - [Nucleus_fillMemory](documentation/Nucleus_fillMemory.md)
 - [Nucleus_fillArrayMemory](documentation/Nucleus_fillArrayMemory.md)
 - [Nucleus_compareMemory](documentation/Nucleus_compareMemory.md)

--- a/buildsystem/detect_compiler_and_platform.cmake
+++ b/buildsystem/detect_compiler_and_platform.cmake
@@ -5,20 +5,22 @@
 # - NUCLEUS_CPP_COMPILER_ID_CLANG
 # - NUCLEUS_CPP_COMPILER_ID_GCC
 # - NUCLEUS_CPP_COMPILER_ID_MSVC
+# - NUCLEUS_CPP_COMPILER_ID_MINGW
 #
-# If compiler detection succeeds, define NUCLEUS_CPP_COMPILER_ID to NUCLEUS_CPP_COMPILER_ID_CLANG, NUCLEUS_CPP_COMPILER_ID_GCC,
-# or NUCLEUS_CPP_COMPILER_ID_CLANG_MSVC. Define IDLIX_CPP_COMPILER_ID to NUCLEUS_CPP_COMPILER_ID_UNKNOWN otherwise. Defines the
-# macro nucleus_report_cpp_compiler_id to report the value of NUCLEUS_CPP_COMPILER_ID.
+# If compiler detection succeeds, define NUCLEUS_CPP_COMPILER_ID to one of the constants listed above except for
+# NUCLEUS_CPP_COMPILER_ID_UNKNOWN. If compiler detection fails, define NUCLEUS_CPP_COMPILER_ID to
+# NUCLEUS_CPP_COMPILER_ID_UNKNOWN. Defines the macro nucleus_report_cpp_compiler_id to report the value of NUCLEUS_CPP_COMPILER_ID.
 
 # Provides the following numeric constants for identifying C compilers:
 # - NUCLEUS_C_COMPILER_ID_UNKNOWN
 # - NUCLEUS_C_COMPILER_ID_CLANG
 # - NUCLEUS_C_COMPILER_ID_GCC
 # - NUCLEUS_C_COMPILER_ID_MSVC
+# - NUCLEUS_C_COMPILER_ID_MINGW
 #
-# If compiler detection succeeds, define NUCLEUS_C_COMPILER_ID to NUCLEUS_C_COMPILER_ID_CLANG, NUCLEUS_C_COMPILER_ID_GCC,
-# or NUCLEUS_C_COMPILER_ID_CLANG_MSVC. Define IDLIX_CPP_COMPILER_ID to NUCLEUS_C_COMPILER_ID_UNKNOWN otherwise. Defines the
-# macro nucleus_report_c_compiler_id to report the value of NUCLEUS_C_COMPILER_ID.
+# If compiler detection succeeds, define NUCLEUS_C_COMPILER_ID to one of the constants listed above except for
+# NUCLEUS_C_COMPILER_ID_UNKNOWN. If compiler detection fails, define NUCLEUS_C_COMPILER_ID to
+# NUCLEUS_C_COMPILER_ID_UNKNOWN otherwise. Defines the macro nucleus_report_c_compiler_id to report the value of NUCLEUS_C_COMPILER_ID.
 #
 #
 # Provides the following numeric constants:
@@ -40,6 +42,7 @@ set(NUCLEUS_C_COMPILER_ID_UNKNOWN 0)
 set(NUCLEUS_C_COMPILER_ID_CLANG 1)
 set(NUCLEUS_C_COMPILER_ID_MSVC 2)
 set(NUCLEUS_C_COMPILER_ID_GCC 3)
+set(NUCLEUS_C_COMPILER_ID_MINGW 4)
 
 set(NUCLEUS_C_COMPILER_ID ${NUCLEUS_C_COMPILER_ID_UNKNOWN})
 
@@ -58,6 +61,11 @@ if (CMAKE_C_COMPILER_ID)
       #message("compiler `MSVC` detected")
       set(NUCLEUS_C_COMPILER_ID ${NUCLEUS_C_COMPILER_ID_MSVC})
     endif()
+
+    if (MINGW)
+      #message("compiler `MINGW` detected")
+      set(NUCLEUS_C_COMPILER_ID ${NUCLEUS_C_COMPILER_ID_MINGW})
+    endif()
 endif()
 
 macro(nucleus_report_c_compiler_id)
@@ -67,6 +75,8 @@ macro(nucleus_report_c_compiler_id)
     message("  - Nucleus C Compiler Id: GCC")
   elseif (${NUCLEUS_C_COMPILER_ID} EQUAL ${NUCLEUS_C_COMPILER_ID_MSVC})
     message("  - Nucleus C Compiler Id: MSVC")
+  elseif (${NUCLEUS_C_COMPILER_ID} EQUAL ${NUCLEUS_C_COMPILER_ID_MINGW})
+    message("  - Nucleus C Compiler Id: MINGW")
   elseif (${NUCLEUS_C_COMPILER_ID} EQUAL ${NUCLEUS_C_COMPILER_ID_UNKNOWN})
     message("  - Nucleus C Compiler Id: Unknown")
   else()
@@ -80,23 +90,30 @@ set(NUCLEUS_CPP_COMPILER_ID_UNKNOWN 0)
 set(NUCLEUS_CPP_COMPILER_ID_CLANG 1)
 set(NUCLEUS_CPP_COMPILER_ID_MSVC 2)
 set(NUCLEUS_CPP_COMPILER_ID_GCC 3)
+set(NUCLEUS_CPP_COMPILER_ID_MINGW 4)
 
 set(NUCLEUS_CPP_COMPILER_ID ${NUCLEUS_CPP_COMPILER_ID_UNKNOWN})
 
-if (CMAKE_CPP_COMPILER_ID)
-    if (CMAKE_CPP_COMPILER MATCHES ".*clang")
+message("CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
+if (CMAKE_CXX_COMPILER_ID)
+    if (CMAKE_CXX_COMPILER MATCHES ".*clang")
       #message("compiler `CLANG` detected")
       set(NUCLEUS_CPP_COMPILER_ID ${NUCLEUS_CPP_COMPILER_ID_CLANG})
     endif()
 
-    if (CMAKE_CPP_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       #message("compiler `GCC` detected")
       set(NUCLEUS_CPP_COMPILER_ID ${NUCLEUS_CPP_COMPILER_ID_GCC})
     endif()
 
-    if (CMAKE_CPP_COMPILER_ID STREQUAL "MSVC")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       #message("compiler `MSVC` detected")
       set(NUCLEUS_CPP_COMPILER_ID ${NUCLEUS_CPP_COMPILER_ID_MSVC})
+    endif()
+
+    if (MINGW)
+      #message("compiler `MINGW` detected")
+      set(NUCLEUS_CPP_COMPILER_ID ${NUCLEUS_CPP_COMPILER_ID_MINGW})
     endif()
 endif()
 
@@ -107,6 +124,8 @@ macro(nucleus_report_cpp_compiler_id)
     message("  - Nucleus C++ Compiler Id: GCC")
   elseif (${NUCLEUS_CPP_COMPILER_ID} EQUAL ${NUCLEUS_CPP_COMPILER_ID_MSVC})
     message("  - Nucleus C++ Compiler Id: MSVC")
+  elseif (${NUCLEUS_CPP_COMPILER_ID} EQUAL ${NUCLEUS_CPP_COMPILER_ID_MINGW})
+    message("  - Nucleus C++ Compiler Id: MINGW")
   elseif (${NUCLEUS_CPP_COMPILER_ID} EQUAL ${NUCLEUS_CPP_COMPILER_ID_UNKNOWN})
     message("  - Nucleus C++ Compiler Id: Unknown")
   else()

--- a/buildsystem/set_default_project_properties.cmake
+++ b/buildsystem/set_default_project_properties.cmake
@@ -97,12 +97,23 @@ macro(set_project_default_properties)
       CMAKE_CXX_FLAGS_MINSIZEREL
       CMAKE_CXX_FLAGS_RELEASE
       CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    foreach(variable ${variables})
-    if(${variable} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+    if (With-Static-Runtime)
+      # Enable static runtime.
+      foreach(variable ${variables})
+        if(${variable} MATCHES "/MD")
+          string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+        endif()
+      endforeach()
+      set(MSVC_RUNTIME "static")
+    else()
+      # Enable dynamic runtime.
+      foreach(variable ${variables})
+        if(${variable} MATCHES "/MT")
+          string(REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
+        endif()
+      endforeach()
+      set(MSVC_RUNTIME "dynamic")
     endif()
-    endforeach()
-    set(MSVC_RUNTIME "static")
   endif()
 
   # (3) MSVC C++ settings

--- a/documentation/Nucleus_[FloatingPointType].md
+++ b/documentation/Nucleus_[FloatingPointType].md
@@ -15,7 +15,7 @@ definitions are supporting orthogonality of naming.
 
 
 
-# `[FloatingPointType]_Greatest`, `[FloatingPointType]_Least`
+# `Nucleus_[FloatingPointType]_Greatest`, `Nucleus_[FloatingPointType]_Least`
 
 ## C Signature
 ```
@@ -31,7 +31,7 @@ of values of the the type `Nucleus_[FloatingPointType]`.
 
 
 
-# `[FloatingPointType]_NaN`
+# `Nucleus_[FloatingPointType]_NaN`
 
 ## C Signature
 ```
@@ -44,7 +44,7 @@ where `[FloatingPointType]` is one of `Single`, `Double`, or `Quadruple`.
 
 
 
-# `[FloatingPointType]_PositiveInfinity`, `[FloatingPointType]_NegativeInfinity`
+# `Nucleus_[FloatingPointType]_PositiveInfinity`, `Nucleus_[FloatingPointType]_NegativeInfinity`
 
 ## C Signature
 ```
@@ -59,6 +59,22 @@ where `[FloatingPointType]` is one of `Single`, `Double`, or `Quadruple`.
 
 
 
+
+# `Nucleus_[FloatingPointType]_LeastExponentValueBase[Base]`, `Nucleus_[FloatingPointType]_GreatestExponentValueBase[Base]`
+
+## C Signature
+```
+#define Nucleus_[FloatingPointType]_GreatestExponentValue[Base] /* hidden */
+#define Nucleus_[FloatingPointType]_LeastExponentValue[Base] /* hidden */
+```
+where `[FloatingPointType]` is one of `Single`, `Double`, or `Quadruple` and `[Base]` is one of `2` or `10`.
+
+## Description
+`Nucleus_[FloatingPointType]_GreatestExponentValue[Base]` is the greatest integer such that `[Base]` raised by power
+__one more than that__ is a normalized floating-point number of type `Nucleus_[FloatingPointType]`.
+
+`Nucleus_[FloatingPointType]_LeatExponentValue[Base]` is the least integer such that `[Base]` raised by power
+__one less than that__ is a normalized floating-point number of type `Nucleus_[FloatingPointType]`.
 
 ## Requirements
 

--- a/documentation/Nucleus_cloneArrayMemory.md
+++ b/documentation/Nucleus_cloneArrayMemory.md
@@ -1,0 +1,39 @@
+# `Nucleus_cloneArrayMemory`
+*Clone a memory block.*
+
+## C Signature
+```
+Nucleus_Status
+Nucleus_cloneArrayMemory
+    (
+        void **p,
+        const void *q,
+        Nucleus_Size n,
+        Nucleus_Size m
+    );
+```
+
+## Parameters
+- `p` a pointer to a `void *` variable
+- `q` a pointer to a memory block
+- `n`, `m` the size, in Bytes, of the memory block pointed to by `q`. Note that `0` is a valid size.
+
+## Description
+This function clones a memory block.
+
+A memory block with the same size and the same contents as the specified memory block `(q,n*m)` is allocated, its
+address is assigned to `*p` and `Nucleus_Status_Success` is returned. This function fails if and only if
+- `p` or `q` are null pointers, or
+- the allocation of the memory block failed,
+- `n * m` would overflow
+
+Under the first condition `Nucleus_InvalidArgument` is returned,
+under the second condition `Nucleus_AllocationFailed`` is returned, and
+under the third condition `Nucleus_Overflow` is returned.
+
+## Requirements
+
+|                      | Windows                  | Linux                     |
+|----------------------|--------------------------|---------------------------|
+| *Header*             | `Nucleus/Memory.h`       | `Nucleus/Memory.h`        |
+| *Static library*     | `Nucleus.Library.lib`    | `libNucleus.Library.a`    |

--- a/documentation/Nucleus_cloneMemory.md
+++ b/documentation/Nucleus_cloneMemory.md
@@ -1,0 +1,36 @@
+# `Nucleus_cloneMemory`
+*Clone a memory block.*
+
+## C Signature
+```
+Nucleus_Status
+Nucleus_cloneMemory
+    (
+        void **p,
+        const void *q,
+        Nucleus_Size n
+     );
+```
+
+## Parameters
+- `p` a pointer to a `void *` variable
+- `q` a pointer to the memory block to be cloned
+- `n` the size, in Bytes, of the memory block pointed to by `q`. Note that `0` is a valid size.
+
+## Description
+This function clones a memory block.
+
+A memory block with the same size and the same contents as the specified memory block `(q,n)` is allocated, its address
+is assigned to `*p` and `Nucleus_Status_Success` is returned. This function fails if and only if
+- `p` or `q` are null pointers, or
+- the allocation of the memory block failed.
+
+Under the former condition `Nucleus_Status_InvalidArgument` is returned,
+under the latter condition `Nucleus_Status_AllocationFailed` is returned.
+
+## Requirements
+
+|                      | Windows                  | Linux                     |
+|----------------------|--------------------------|---------------------------|
+| *Header*             | `Nucleus/Memory.h`       | `Nucleus/Memory.h`        |
+| *Static library*     | `Nucleus.Library.lib`    | `libNucleus.Library.a`    |

--- a/documentation/Nucleus_reallocateArrayMemory.md
+++ b/documentation/Nucleus_reallocateArrayMemory.md
@@ -7,31 +7,31 @@ Nucleus_Status
 Nucleus_reallocateArrayMemory
     (
         void **p,
-        size_t n,
-        size_t m
+        Nucleus_Size n,
+        Nucleus_Size m
     );
 ```
 
 ## Parameters
 - `p` a pointer to a `void *` variable
-- `n`, `m` the product of @a n and @a m is the size, in Bytes, of the memory block to allocate. Note that @a 0 is a valid size.
+- `n`, `m` the product of @a n and @a m is the size, in Bytes, of the memory block to allocate. Note that `0` is a valid size.
 
 ## Description
 This function reallocates a memory block.
 
 If this function succeeds, then this function conceptually performed the following tasks:
-The function conceptually allocates a new memory block of size `n * m` and copies `min(n * m,k)` Bytes from the old
+The function allocates a new memory block of size `n * m` and copies `min(n * m,k)` Bytes from the old
 memory block pointed to by `*p` of size `k` to the new memory block. The old memory block is then deallocated.
 The address of the new memory block is is assigned to `*p` and `Nucleus_Status_Success` is returned.
 
 This function fails if and only if one or more of the following conditions are met:
 - `p` or `*p` is a null pointer
-- `n * m` would overflow
 - the allocation of the new memory block failed
+- `n * m` would overflow
 
 Under the first condition `Nucleus_InvalidArgument` is returned,
-under the second condition `Nucleus_Overflow` is returned, and
-under the third condition `Nucleus_AllocationFailed`` is returned.
+under the second condition `Nucleus_AllocationFailed`` is returned, and
+under the third condition `Nucleus_Overflow` is returned.
 
 ## Requirements
 

--- a/documentation/Nucleus_reallocateMemory.md
+++ b/documentation/Nucleus_reallocateMemory.md
@@ -8,7 +8,7 @@ Nucleus_Status
 Nucleus_reallocateMemory
     (
         void **p,
-        size_t n
+        Nucleus_Size n
     );
 ```
 
@@ -20,7 +20,7 @@ Nucleus_reallocateMemory
 This function reallocates a memory block.
 
 If this function succeeds, then this function conceptually performed the following tasks:
-The function conceptually allocates a new memory block of size `n` and copies `min(n, k)` Bytes from the old
+The function allocates a new memory block of size `n` and copies `min(n, k)` Bytes from the old
 memory block pointed to by `*p` of size `k` to the new memory block. The old memory block is then deallocated.
 The address of the new memory block is is assigned to `*p` and `Nucleus_Status_Success` is returned.
 
@@ -28,9 +28,8 @@ This function fails if and only if one or more of the following conditions are m
 - `p` or `*p` is a null pointer or
 - the allocation of the new memory block failed
 
-
-Under the former condition `Nucleus_InvalidArgument` is returned and
-under the latter condition `Nucleus_AllocationFailed` is returned.
+Under the former condition `Nucleus_InvalidArgument` is returned,
+under the latter condition `Nucleus_AllocationFailed`` is returned.
 
 ## Requirements
 

--- a/library/src/Nucleus/DecimalFloat.c
+++ b/library/src/Nucleus/DecimalFloat.c
@@ -164,9 +164,9 @@ isEnd
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-static const Nucleus_DecimalDigit NaN[] = { 'n', 'a', 'n' };
+static const Nucleus_DecimalFloat_Digit NaN[] = { 'n', 'a', 'n' };
 
-static const Nucleus_DecimalDigit Inf[] = { 'i', 'n', 'f' };
+static const Nucleus_DecimalFloat_Digit Inf[] = { 'i', 'n', 'f' };
 
 Nucleus_NonNull() Nucleus_Status
 Nucleus_DecimalFloat_createNaN
@@ -199,7 +199,7 @@ Nucleus_DecimalFloat_createInf
     if (status) return status;
     temporary->sign = sign;
     temporary->numberOfDigits = 0;
-    temporary->digits = (Nucleus_Natural8 *)Inf;
+    temporary->digits = (Nucleus_DecimalFloat_Digit *)Inf;
     temporary->exponent = 0;
     *decimalFloat = temporary;
     return Nucleus_Status_Success;
@@ -243,7 +243,7 @@ Nucleus_DecimalFloat_create_fromString
         .magnitude = 0,
     };
 
-    status = Nucleus_allocateArrayMemory((void **)&buffer, numberOfBytes, sizeof(uint8_t));
+    status = Nucleus_allocateArrayMemory((void **)&buffer, numberOfBytes, sizeof(Nucleus_DecimalFloat_Digit));
     if (status) return status;
 
     Nucleus_Integer32 decimalExponent = -((Nucleus_Integer32)(fractional.end - fractional.begin));
@@ -470,8 +470,8 @@ Nucleus_DecimalFloat_destroy
         Nucleus_DecimalFloat *decimalFloat
     )
 {
-    if (decimalFloat->digits != (Nucleus_Natural8 *)Inf &&
-        decimalFloat->digits != (Nucleus_Natural8 *)NaN)
+    if (decimalFloat->digits != (Nucleus_DecimalFloat_Digit *)Inf &&
+        decimalFloat->digits != (Nucleus_DecimalFloat_Digit *)NaN)
     {
         Nucleus_deallocateMemory(decimalFloat->digits);
         decimalFloat->digits = NULL;
@@ -511,7 +511,7 @@ Nucleus_DecimalFloat_isNegativeInfinity
     )
 {
     if (Nucleus_Unlikely(!decimalFloat || !isNegativeInfinity)) return Nucleus_Status_InvalidArgument;
-    *isNegativeInfinity = decimalFloat->sign == Nucleus_Sign_Minus && decimalFloat->digits == (Nucleus_DecimalDigit *)Inf;
+    *isNegativeInfinity = decimalFloat->sign == Nucleus_Sign_Minus && decimalFloat->digits == (Nucleus_DecimalFloat_Digit *)Inf;
     return Nucleus_Status_Success;
 }
 
@@ -532,7 +532,7 @@ Nucleus_DecimalFloat_getDigit
     (
         Nucleus_DecimalFloat *decimalFloat,
         Nucleus_Size indexOfDigit,
-        Nucleus_DecimalDigit *digit
+        Nucleus_DecimalFloat_Digit *digit
     )
 {
     if (Nucleus_Unlikely(!decimalFloat || !digit)) return Nucleus_Status_InvalidArgument;

--- a/library/src/Nucleus/DecimalFloat.h
+++ b/library/src/Nucleus/DecimalFloat.h
@@ -10,7 +10,7 @@
 #include "Nucleus/Types/Size.h"
 #include "Nucleus/Sign.h"
 
-typedef uint8_t Nucleus_DecimalDigit;
+typedef uint8_t Nucleus_DecimalFloat_Digit;
 
 typedef struct Nucleus_DecimalFloat Nucleus_DecimalFloat;
 
@@ -19,7 +19,7 @@ struct Nucleus_DecimalFloat
     Nucleus_Sign sign;
     Nucleus_Integer64 exponent;
     Nucleus_Size numberOfDigits;
-    Nucleus_DecimalDigit *digits;
+    Nucleus_DecimalFloat_Digit *digits;
 }; // struct Nucleus_DecimalFloat
 
 Nucleus_NonNull() Nucleus_Status
@@ -82,5 +82,5 @@ Nucleus_DecimalFloat_getDigit
     (
         Nucleus_DecimalFloat *decimalFloat,
         Nucleus_Size indexOfDigit,
-        Nucleus_DecimalDigit *digit
+        Nucleus_DecimalFloat_Digit *digit
     );

--- a/library/src/Nucleus/DecimalInteger-private.c.i
+++ b/library/src/Nucleus/DecimalInteger-private.c.i
@@ -1,0 +1,283 @@
+#include "Nucleus/DecimalInteger-private.h.i"
+
+Nucleus_NonNull() static Nucleus_Status
+addSameSigns
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    )
+{
+    if (Nucleus_Unlikely(!x || !y)) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(x->sign != y->sign)) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status;
+    // Determine which of "x" and "y" has more digits. "small" points to the number with the least amount of digits,
+    // "big" points to the number with the greatest amount of digits. If "x" and "y" have the same number of digits,
+    // then "small" points to "x" and "big" points to "y".
+    const Nucleus_DecimalInteger *small = x, *big = y;
+    if (small->numberOfDigits > big->numberOfDigits)
+    {
+        const Nucleus_DecimalInteger *t = (const Nucleus_DecimalInteger *)small;
+        small = big;
+        big = t;
+    }
+    // Make room for "big.numberOfDigits" plus one digits.
+    Nucleus_DecimalInteger_Digit *digits;
+    Nucleus_Size numberOfDigits = big->numberOfDigits;
+    status = Nucleus_allocateArrayMemory((void **)&digits, big->numberOfDigits + 1,
+                                         sizeof(Nucleus_DecimalInteger_Digit));
+    if (status) return status;
+    // Iterate over "[0, small.numberOfDigits)]".
+    Nucleus_Size i;
+    Nucleus_Size c;
+    for (i = 0, c = 0; i < small->numberOfDigits; ++i)
+    {
+        Nucleus_DecimalInteger_Digit t = small->digits[i] - big->digits[i] + c;
+        t /= BASE;
+        c %= BASE;
+        digits[i] = t;
+    }
+    // Iterate over "[small.numberOfDigits, big.numberOfDigits)".
+    for(; i < big->numberOfDigits; ++i)
+    {
+        // sum of carry (0 + 1) and one digit (0 to 9) yields a maximal value of 10.
+        Nucleus_DecimalInteger_Digit t = big->digits[i] + c;
+        if (t > 9)
+        {
+            t = t - 10;
+            c = 1;
+        }
+        digits[i] = t;
+    }
+
+    if (c)
+    {
+        digits[i] = 1;
+        numberOfDigits += 1;
+    }
+
+    Nucleus_deallocateMemory(x->digits);
+
+    x->digits = digits;
+    x->numberOfDigits = numberOfDigits;
+    x->capacityInDigits = numberOfDigits;
+
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static Nucleus_Status
+subtractSameSigns
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    )
+{
+    if (Nucleus_Unlikely(!x || !y)) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(x->sign != y->sign)) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status;
+    // Determine the sign of the operands.
+    Nucleus_DecimalInteger_Sign sign = x->sign;
+    // The least number of digits.
+    Nucleus_Size leastNumberOfDigits, greatestNumberOfDigits;
+    if (x->numberOfDigits < y->numberOfDigits)
+    {
+        leastNumberOfDigits = x->numberOfDigits;
+        greatestNumberOfDigits = y->numberOfDigits;
+    }
+    else
+    {
+        leastNumberOfDigits = x->numberOfDigits;
+        greatestNumberOfDigits = y->numberOfDigits;
+    }
+    // Make room for "greatestNumberOfDigits + 1".
+    Nucleus_DecimalInteger_Digit *digits;
+    Nucleus_Size numberOfDigits = greatestNumberOfDigits + 1;
+    status = Nucleus_allocateArrayMemory((void **)&digits, numberOfDigits, sizeof(Nucleus_DecimalInteger_Digit));
+    if (status) return status;
+    // Iterate over "[0, leastNumberOfDigits)]".
+    Nucleus_Size i;
+    Nucleus_Size c = 0;
+    for (i = 0, c = 0; i < leastNumberOfDigits; ++i)
+    {
+        Nucleus_DecimalInteger_Digit t = x->digits[i] - y->digits[i] + c;
+        t /= BASE;
+        c %= BASE;
+        digits[i] = t;
+    }
+    // Iterate over "[leastNumberOfDigits, greatestNumberOfDigits)".
+    Nucleus_DecimalInteger *big = x;
+    if (x->numberOfDigits < y->numberOfDigits)
+    {
+        big = (Nucleus_DecimalInteger *)y;
+    }
+    for(; i < greatestNumberOfDigits; ++i)
+    {
+        Nucleus_DecimalInteger_Digit t = big->digits[i] + c;
+        t /= BASE;
+        c %= BASE;
+        digits[i] = t;
+    }
+
+    // A non-0 value of c (i.e. -1) indicates that the sign needs to be swapped.
+    if (c)
+    {
+        digits[i] = 1; // As carry is 0 or -1.
+        numberOfDigits += 1;
+        switch (sign)
+        {
+        case Nucleus_DecimalInteger_Sign_Plus:
+            sign = Nucleus_DecimalInteger_Sign_Minus;
+            break;
+        case Nucleus_DecimalInteger_Sign_Minus:
+            sign = Nucleus_DecimalInteger_Sign_Plus;
+            break;
+        };
+    }
+
+    Nucleus_deallocateMemory(x->digits);
+
+    x->sign = sign;
+    x->digits = digits;
+    x->numberOfDigits = numberOfDigits;
+    x->capacityInDigits = numberOfDigits;
+
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() static Nucleus_Status
+add
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    )
+{
+    if (Nucleus_Unlikely(!x || !y)) return Nucleus_Status_InvalidArgument;
+    if (x->sign == y->sign)
+    {
+        return addSameSigns(x, y);
+    }
+    else
+    {
+        Nucleus_Status status;
+        Nucleus_DecimalInteger *z;
+        //
+        status = Nucleus_DecimalInteger_clone(&z, y);
+        if (status) return status;
+        status = Nucleus_DecimalInteger_negate(z);
+        if (status) return status;
+        //
+        status = subtractSameSigns(x, z);
+        Nucleus_DecimalInteger_destroy(z);
+        //
+        return status;
+    }
+}
+
+Nucleus_NonNull() static Nucleus_Status
+subtract
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    )
+{
+    if (Nucleus_Unlikely(!x || !y)) return Nucleus_Status_InvalidArgument;
+    if (x->sign == y->sign)
+    {
+        return subtractSameSigns(x, y);
+    }
+    else
+    {
+        Nucleus_Status status;
+        Nucleus_DecimalInteger *z;
+        //
+        status = Nucleus_DecimalInteger_clone(&z, y);
+        if (status) return status;
+        //
+        status = Nucleus_DecimalInteger_negate(z);
+        if (status) return status;
+        //
+        status = addSameSigns(x, z);
+        Nucleus_DecimalInteger_destroy(z);
+        //
+        return status;
+    }
+}
+
+Nucleus_NonNull() static Nucleus_Status
+compare
+    (
+        const Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y,
+        int *r
+    )
+{
+    if (Nucleus_Unlikely(!x || !y || !r)) return Nucleus_Status_InvalidArgument;
+
+    Nucleus_Boolean isZeroX = x->digits[0] == 0 && x->numberOfDigits == 1,
+                    isZeroY = y->digits[0] == 0 && y->numberOfDigits == 1;
+    
+    // If x and y are both 0 then they are equal.
+    if (isZeroX && isZeroY)
+    {
+        *r = 0;
+        return Nucleus_Status_Success;
+    }
+
+    Nucleus_DecimalInteger_Sign signX = x->sign,
+                                signY = y->sign;
+    // If an operand is zero, force its sign to 
+    if (isZeroX) signX = Nucleus_DecimalInteger_Sign_Plus;
+    if (isZeroY) signY = Nucleus_DecimalInteger_Sign_Plus;
+
+    // INV1: At this point x or y are non-zero.
+    // At this point INV1 holds.
+
+    // If x has a minus sign and y has a plus sign ...
+    if (signX == Nucleus_DecimalInteger_Sign_Minus && signY == Nucleus_DecimalInteger_Sign_Plus)
+    {
+        // ... then x is negative and y is non-negative.
+        // Hence x is smaller than y.
+        *r = -1;
+        return Nucleus_Status_Success;
+    }
+    // If x has plus sign and y has a minus sign ...
+    if (signX == Nucleus_DecimalInteger_Sign_Plus && signY == Nucleus_DecimalInteger_Sign_Minus)
+    {
+        // ... then x is non-negative and y is negative.
+        // Hence x is greater than y.
+        *r = +1;
+        return Nucleus_Status_Success;
+    }
+
+    // INV2: At this point x and y have the same sign.
+    // At this point INV1 and INV2 hold.
+
+    if (x->numberOfDigits > y->numberOfDigits)
+    {
+        (*r) = +1;
+        return Nucleus_Status_Success;
+    }
+    else if (x->numberOfDigits < y->numberOfDigits)
+    {
+        (*r) = -1;
+        return Nucleus_Status_Success;
+    }
+
+    // INV3: The numbe of digits of x and y is equal.
+    // At this point INV1, INV2, and INV3 hold.
+    for (Nucleus_Size i = x->numberOfDigits; i > 0; --i)
+    {
+        if (x->digits[i-1] < y->digits[i-1])
+        {
+            (*r) = -1;
+            return Nucleus_Status_Success;
+        }
+        else if (x->digits[i-1] > y->digits[i-1])
+        {
+            (*r) = +1;
+            return Nucleus_Status_Success;
+        }
+    }
+
+    (*r) = 0;
+    return Nucleus_Status_Success;
+}

--- a/library/src/Nucleus/DecimalInteger-private.h.i
+++ b/library/src/Nucleus/DecimalInteger-private.h.i
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "Nucleus/DecimalInteger.h"
+
+#include "Nucleus/Memory.h"
+#include <math.h>
+
+/* The base. */
+static const Nucleus_DecimalInteger_Digit BASE = 10;
+
+/* Addition of two decimal integers with same signs. */
+Nucleus_NonNull() static Nucleus_Status
+addSameSigns
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    );
+
+/* Subtraction of two decimal integers with same signs. */
+Nucleus_NonNull() static Nucleus_Status
+subtractSameSigns
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    );
+
+/*
+ * X + Y
+ * if X.sign = Y.sign then call addSameSigns(X, Y)
+ * if X.sign != Y.sign then call subtractSameSigns(X, -Y)
+ * The latter formula is proper as X + Y ~ X - (Y-)
+ */
+Nucleus_NonNull() static Nucleus_Status
+add
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    );
+
+/* 
+ * X - Y
+ * if X.sign = Y.sign then call subtractSameSigns(X, Y)
+ * if X.sign != Y.sign then call addSameSigns(X, -Y)
+ * The latter formula is proper as X - Y ~ X + (-Y)
+ */
+Nucleus_NonNull() static Nucleus_Status
+subtract
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    );
+
+Nucleus_NonNull() static Nucleus_Status
+compare
+    (
+        const Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y,
+        int *r
+    );

--- a/library/src/Nucleus/DecimalInteger.c
+++ b/library/src/Nucleus/DecimalInteger.c
@@ -1,0 +1,261 @@
+#include "Nucleus/DecimalInteger-private.c.i"
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger8
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer8 integer
+    )
+{ return Nucleus_DecimalInteger_fromInteger64(decimalInteger, integer); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger16
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer16 integer
+    )
+{ return Nucleus_DecimalInteger_fromInteger64(decimalInteger, integer); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger32
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer32 integer
+    )
+{ return Nucleus_DecimalInteger_fromInteger64(decimalInteger, integer); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger64
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer64 integer
+    )
+{
+    if (Nucleus_Unlikely(!decimalInteger)) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status;
+    // Allocate DecimalInteger.
+    Nucleus_DecimalInteger *temporary;
+    status = Nucleus_allocateMemory((void **)&temporary, sizeof(Nucleus_DecimalInteger));
+    if (status) { return status; }
+    // Special case of integer = 0.
+    if (!integer)
+    {
+        temporary->sign = Nucleus_DecimalInteger_Sign_Plus;
+        temporary->numberOfDigits = 1;
+        temporary->capacityInDigits = 1;
+        status = Nucleus_allocateMemory((void **)&temporary->digits, sizeof(Nucleus_DecimalInteger_Digit));
+        if (status)
+        {
+            Nucleus_deallocateMemory(temporary);
+            return status;
+        }
+        temporary->digits[0] = 0;
+        *decimalInteger = temporary;
+        return Nucleus_Status_Success;
+    }
+    // Estimate number of digits and capacity in digits and compute the sign.
+    if (integer < 0) temporary->sign = Nucleus_DecimalInteger_Sign_Minus;
+    else temporary->sign = Nucleus_DecimalInteger_Sign_Plus;
+    // An integer in base 10 has a smaller or equal number of digits compared to an integer in base 2
+    // if both represent the same value. So the number of binary digits is a conservative approximation
+    // of the number of decimal digits.
+    temporary->numberOfDigits = 0;
+    temporary->capacityInDigits = sizeof(Nucleus_Integer64) * 8;
+    // Allocate digits.
+    status = Nucleus_allocateArrayMemory((void **)&temporary->digits, temporary->capacityInDigits,
+                                         sizeof(Nucleus_DecimalInteger_Digit));
+    if (status)
+    {
+        Nucleus_deallocateMemory(temporary);
+        return status;
+    }
+    // Compute the digits.
+    Nucleus_Integer64 v = integer;
+    if (v < 0)
+    {
+        for (Nucleus_Size i = 0; v != 0; ++i)
+        {
+            temporary->digits[i] = -(v % 10);
+            v /= 10;
+            temporary->numberOfDigits++;
+        }
+
+    }
+    else
+    {
+        for (Nucleus_Size i = 0; v != 0; ++i)
+        {
+            temporary->digits[i] = +(v % 10);
+            v /= 10;
+            temporary->numberOfDigits++;
+        }
+    }
+    // Return the result
+    *decimalInteger = temporary;
+    // Return success.
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_create
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_DecimalInteger_Sign sign,
+        const Nucleus_DecimalInteger_Digit *digits,
+        Nucleus_Size numberOfDigits
+    )
+{
+    if (Nucleus_Unlikely(!decimalInteger || !digits || !numberOfDigits)) return Nucleus_Status_InvalidArgument;
+    Nucleus_DecimalInteger *temporary;
+    Nucleus_Status status;
+    status = Nucleus_allocateMemory((void **)&temporary, sizeof(Nucleus_DecimalInteger));
+    if (status) { return status; }
+    status = Nucleus_cloneArrayMemory((void **)&temporary->digits, digits, numberOfDigits,
+                                       sizeof(Nucleus_DecimalInteger_Digit));
+    if (status) { Nucleus_deallocateMemory(temporary); return status; }
+
+    temporary->sign = sign;
+    temporary->numberOfDigits = numberOfDigits;
+    temporary->capacityInDigits = numberOfDigits;
+
+    *decimalInteger = temporary;
+    return Nucleus_Status_Success;
+}
+
+#define OptimizeOnClone (1)
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_clone
+    (
+        Nucleus_DecimalInteger **y,
+        const Nucleus_DecimalInteger *x
+    )
+{
+    if (Nucleus_Unlikely(!y || !x)) return Nucleus_Status_InvalidArgument;
+    //
+    Nucleus_DecimalInteger *temporary;
+    Nucleus_Status status;
+    //
+    status = Nucleus_allocateMemory((void **)&temporary, sizeof(Nucleus_DecimalInteger));
+    if (status) { return status; }
+#if defined(OptimizeOnClone) && 1 == OptimizeOnClone
+    //
+    status = Nucleus_cloneArrayMemory((void **)&temporary->digits, x->digits, x->numberOfDigits,
+                                      sizeof(Nucleus_DecimalInteger_Digit));
+    if (status) { Nucleus_deallocateMemory(temporary); return status; }
+    temporary->sign = x->sign;
+    temporary->numberOfDigits = x->numberOfDigits;
+    temporary->capacityInDigits = x->numberOfDigits;
+#else
+    //
+    status = Nucleus_cloneArrayMemory((void **)&temporary->digits, x->digits, x->capacityInDigits,
+                                      sizeof(Nucleus_DecimalInteger_Digit));
+    if (status) { Nucleus_deallocateMemory(temporary); return status; }
+    temporary->sign = x->sign;
+    temporary->numberOfDigits = x->numberOfDigits;
+    temporary->capacityInDigits = x->capacityInDigits;
+#endif
+    //
+    *y = temporary;
+    //
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() void
+Nucleus_DecimalInteger_destroy
+    (
+        Nucleus_DecimalInteger *decimalInteger
+    )
+{
+    decimalInteger->numberOfDigits = 0;
+    Nucleus_deallocateMemory(decimalInteger->digits);
+    decimalInteger->digits = NULL;
+    decimalInteger->capacityInDigits = 0;
+    Nucleus_deallocateMemory(decimalInteger);
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_trimLeadingZeroes
+    (
+        Nucleus_DecimalInteger *x
+    )
+{
+    if (Nucleus_Unlikely(!x)) return Nucleus_Status_InvalidArgument;
+    Nucleus_Size i, j;
+    for (i = x->numberOfDigits, j = 0; i > 1 && x->digits[i-1] == 0; --i, ++j)
+    {}
+    x->numberOfDigits -= j;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_getNumberOfDigits
+    (
+        Nucleus_DecimalInteger *decimalInteger,
+        Nucleus_Size *numberOfDigits
+    )
+{
+    if (Nucleus_Unlikely(!decimalInteger || !numberOfDigits)) return Nucleus_Status_InvalidArgument;
+    *numberOfDigits = decimalInteger->numberOfDigits;
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_getDigit
+    (
+        Nucleus_DecimalInteger *decimalInteger,
+        Nucleus_Size indexOfDigit,
+        Nucleus_DecimalInteger_Digit *digit
+    )
+{
+    if (Nucleus_Unlikely(!decimalInteger || !digit)) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(indexOfDigit >= decimalInteger->numberOfDigits)) return Nucleus_Status_IndexOutOfBounds;
+    *digit = decimalInteger->digits[indexOfDigit];
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_negate
+    (
+        Nucleus_DecimalInteger *x
+    )
+{
+    if (Nucleus_Unlikely(!x)) return Nucleus_Status_InvalidArgument;
+    switch (x->sign)
+    {
+        case Nucleus_DecimalInteger_Sign_Plus:
+            x->sign = Nucleus_DecimalInteger_Sign_Minus;
+            break;
+        case Nucleus_DecimalInteger_Sign_Minus:
+            x->sign = Nucleus_DecimalInteger_Sign_Plus;
+            break;
+        default:
+            return Nucleus_Status_InternalError;
+    };
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_add
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    )
+{ return add(x,y); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_subtract
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    )
+{ return subtract(x, y); }
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_compare
+    (
+        const Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y,
+        int *r
+    )
+{ return compare(x, y, r); }

--- a/library/src/Nucleus/DecimalInteger.h
+++ b/library/src/Nucleus/DecimalInteger.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "Nucleus/Annotations.h"
+#include "Nucleus/Status.h"
+#include "Nucleus/Types/Integer.h"
+#include "Nucleus/Types/Natural.h"
+#include "Nucleus/Types/Size.h"
+
+typedef enum Nucleus_DecimalInteger_Sign Nucleus_DecimalInteger_Sign;
+enum Nucleus_DecimalInteger_Sign
+{
+    Nucleus_DecimalInteger_Sign_Plus,
+    Nucleus_DecimalInteger_Sign_Minus,
+}; // enum Nucleus_DecimalInteger_Sign
+
+typedef Nucleus_Natural8 Nucleus_DecimalInteger_Digit;
+
+typedef struct Nucleus_DecimalInteger Nucleus_DecimalInteger;
+
+struct Nucleus_DecimalInteger
+{
+    /// @brief A pointer to an array of @a numberOfDigits @a (Nucleus_DecimalDigit) values.
+    /// @a (digit[0]) is the least significant digit.
+    Nucleus_DecimalInteger_Digit *digits;
+    /// @brief The number of used elements in the array pointed to by @a digits.
+    /// This number is at least @a 1.
+    Nucleus_Size numberOfDigits;
+    /// @brief The number of elements in the array pointed to by @a digits.
+    /// This number of at least @a 1.
+    Nucleus_Size capacityInDigits;
+    /// @brief The sign of the decimal integer.
+    Nucleus_DecimalInteger_Sign sign;
+}; // struct Nucleus_DecimalInteger
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger8
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer8 integer
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger16
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer16 integer
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger32
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer32 integer
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_fromInteger64
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_Integer64 integer
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_create
+    (
+        Nucleus_DecimalInteger **decimalInteger,
+        Nucleus_DecimalInteger_Sign sign,
+        const Nucleus_DecimalInteger_Digit *digits,
+        Nucleus_Size numberOfDigits
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_clone
+    (
+        Nucleus_DecimalInteger **y,
+        const Nucleus_DecimalInteger *x
+    );
+
+Nucleus_NonNull() void
+Nucleus_DecimalInteger_destroy
+    (
+        Nucleus_DecimalInteger *decimalInteger
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_trimLeadingZeroes
+    (
+        Nucleus_DecimalInteger *x
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_getNumberOfDigits
+    (
+        Nucleus_DecimalInteger *decimalInteger,
+        Nucleus_Size *numberOfDigits
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_getDigit
+    (
+        Nucleus_DecimalInteger *decimalInteger,
+        Nucleus_Size indexOfDigit,
+        Nucleus_DecimalInteger_Digit *digit
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_negate
+    (
+        Nucleus_DecimalInteger *x
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_add
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_subtract
+    (
+        Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y
+    );
+
+Nucleus_NonNull() Nucleus_Status
+Nucleus_DecimalInteger_compare
+    (
+        const Nucleus_DecimalInteger *x,
+        const Nucleus_DecimalInteger *y,
+        int *r
+    );

--- a/library/src/Nucleus/Memory.c
+++ b/library/src/Nucleus/Memory.c
@@ -185,3 +185,33 @@ Nucleus_compareArrayMemory
     if (status) return status;
     return Nucleus_compareMemory(p, q, k, r);
 }
+
+Nucleus_NoError() Nucleus_NonNull(1, 2) Nucleus_Status
+Nucleus_cloneMemory
+    (
+        void **p,
+        const void *q,
+        Nucleus_Size n
+     )
+{
+    if (Nucleus_Unlikely(!p || !q)) return Nucleus_Status_InvalidArgument;
+    Nucleus_Status status = Nucleus_allocateMemory(p, n);
+    if (status) return status;
+    memcpy(*p, q, n);
+    return Nucleus_Status_Success;
+}
+
+Nucleus_NoError() Nucleus_NonNull(1, 2) Nucleus_Status
+Nucleus_cloneArrayMemory
+    (
+        void **p,
+        const void *q,
+        Nucleus_Size n,
+        Nucleus_Size m
+    )
+{
+    Nucleus_Size k;
+    Nucleus_Status status = Nucleus_safeMulSize(n, m, &k);
+    if (status) return status;
+    return Nucleus_cloneMemory(p, q, k);
+}

--- a/library/src/Nucleus/Memory.h
+++ b/library/src/Nucleus/Memory.h
@@ -106,3 +106,22 @@ Nucleus_compareArrayMemory
         Nucleus_Size m,
         Nucleus_Boolean *r
     );
+
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_cloneMemory.md
+Nucleus_NoError() Nucleus_NonNull(1, 2) Nucleus_Status
+Nucleus_cloneMemory
+    (
+        void **p,
+        const void *q,
+        Nucleus_Size n
+     );
+
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_cloneArrayMemory.md
+Nucleus_NoError() Nucleus_NonNull(1, 2) Nucleus_Status
+Nucleus_cloneArrayMemory
+    (
+        void **p,
+        const void *q,
+        Nucleus_Size n,
+        Nucleus_Size m
+    );

--- a/library/src/Nucleus/Types/FloatingPoint.h
+++ b/library/src/Nucleus/Types/FloatingPoint.h
@@ -26,7 +26,20 @@ typedef float Nucleus_Single;
 #define Nucleus_Single_NegativeInfinity (-INFINITY)
 
 #define Nucleus_Single_MaximumNumberOfDecimalDigits (FLT_DIG)
-#define Nucleus_Single_MaximumNumberOfDecimalExponentDigits (FLT_MAX_10_EXP)
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+#define Nucleus_Single_GreatestExponentValueBase10 (FLT_MAX_10_EXP)
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+#define Nucleus_Single_LeastExponentValueBase10 (FLT_MIN_10_EXP)
+
+// All machines we're aware of define this to 2 except of IBM 360 and derivatives.
+#if defined(FLT_RADIX) && 2 == FLT_RADIX
+    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    #define Nucleus_Single_GreatestExponentValueBase2 (FLT_MAX_EXP)
+    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    #define Nucleus_Single_LeastExponentValueBase2 (FLT_MIN_EXP)
+#endif
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
@@ -49,7 +62,20 @@ typedef double Nucleus_Double;
 #define Nucleus_Double_NegativeInfinity (-INFINITY)
 
 #define Nucleus_Double_MaximumNumberOfDecimalDigits (DBL_DIG)
-#define Nucleus_Double_MaximumNumberOfDecimalExponentDigits (DBL_MAX_10_EXP)
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+#define Nucleus_Double_GreatestExponentValueBase10 (DBL_MAX_10_EXP)
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+#define Nucleus_Double_LeastExponentValueBase10 (DBL_MIN_10_EXP)
+
+// All machines we're aware of define this to 2 except of IBM 360 and derivatives.
+#if defined(FLT_RADIX) && 2 == FLT_RADIX
+    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    #define Nucleus_Double_GreatestExponentValueBase2 (DBL_MAX_EXP)
+    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    #define Nucleus_Double_LeastExponentValueBase2 (DBL_MIN_EXP)
+#endif
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
@@ -72,6 +98,19 @@ typedef long double Nucleus_Quadruple;
 #define Nucleus_Quadruple_NegativeInfinity (-INFINITY)
 
 #define Nucleus_Quadruple_MaximumNumberOfDecimalDigits (LDBL_DIG)
-#define Nucleus_Quadruple_MaximumNumberOfDecimalExponentDigits (LDBL_MAX_10_EXP)
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+#define Nucleus_Quadruple_GreatestExponentValueBase10 (LDBL_MAX_10_EXP)
+
+// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+#define Nucleus_Quadruple_LeastExponentValueBase10 (LDBL_MIN_10_EXP)
+
+// All machines we're aware of define this to 2 except of IBM 360 and derivatives.
+#if defined(FLT_RADIX) && 2 == FLT_RADIX
+    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    #define Nucleus_Quadruple_GreatestExponentValueBase2 (LDBL_MAX_EXP)
+    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    #define Nucleus_Quadruple_LeastExponentValueBase2 (LDBL_MIN_EXP)
+#endif
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) Michael Heilmann 2017, 2018
 
 add_subdirectory(empty)
-add_subdirectory(FloatingDecimal)
+add_subdirectory(DecimalFloat)
+add_subdirectory(DecimalInteger)
 add_subdirectory(setFileContents)
 add_subdirectory(getFileContents)
 add_subdirectory(booleanToString)

--- a/test/DecimalFloat/CMakeLists.txt
+++ b/test/DecimalFloat/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Michael Heilmann 2017, 2018
+
+# Minimum required CMake version.
+cmake_minimum_required(VERSION 3.8)
+
+# Project.
+project (Nucleus.Test.DecimalFloat C)
+message("building Nucleus.Test.DecimalFloat")
+
+if (NUCLEUS_PATH)
+  include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
+  include(${NUCLEUS_PATH}/buildsystem/set_default_project_properties.cmake)
+else()
+  include(${CMAKE_SOURCE_DIR}/buildsystem/detect_compiler_and_platform.cmake)
+  include(${CMAKE_SOURCE_DIR}/buildsystem/set_default_project_properties.cmake)
+endif()
+
+set_project_default_properties()
+
+# Find and configure source files.
+file(GLOB_RECURSE  SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
+# Find and configure header files.
+file(GLOB_RECURSE  HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
+set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
+# Add and configure executable.
+add_executable(Nucleus.Test.DecimalFloat ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(Nucleus.Test.DecimalFloat Nucleus.Library)
+
+# Test.
+add_test(NAME Nucleus.Test.DecimalFloat COMMAND $<TARGET_FILE:Nucleus.Test.DecimalFloat>
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/DecimalFloat/src/Nucleus.Test.DecimalFloat/main.c
+++ b/test/DecimalFloat/src/Nucleus.Test.DecimalFloat/main.c
@@ -1,0 +1,88 @@
+#include "Nucleus/DecimalFloat.h"
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct Test
+{
+    const char *inputString;
+    Nucleus_Boolean isNaN;
+    Nucleus_Boolean isPositiveInfinity;
+    Nucleus_Boolean isNegativeInfinity;
+    Nucleus_Size numberOfDigits;
+    Nucleus_Integer64 exponent;
+} Test;
+
+static const Test Tests[] =
+{
+    { "NaN",  true,  false, false,  -1 },
+    { "+Inf", false, true,  false,  -1 },
+    { "-Inf", false, false, true,   -1 },
+    { "Inf",  false, true,  false,  -1 },
+    //
+    { "0.0",   false, false, false,  +1, 0 },
+    { "0.00",  false, false, false,  +1, 0 },
+    { "00.0",  false, false, false,  +1, 0 },
+    { "00.00", false, false, false,  +1, 0 },
+    //
+    { "10.1",   false, false, false,  +3, -1 },
+    { "10.10",  false, false, false,  +3, -1 },
+    { "010.1",  false, false, false,  +3, -1 },
+    { "010.10", false, false, false,  +3, -1 },
+};
+
+static const Nucleus_Size NumberOfTests = sizeof(Tests) / sizeof(Test);
+
+static Nucleus_Status
+test
+    (
+    )
+{
+    Nucleus_Status status = Nucleus_Status_Success;
+    for (Nucleus_Size i = 0, n = NumberOfTests; i < n; ++i)
+    {
+        const Test *test = &(Tests[i]);
+        const char *inputString = test->inputString;
+        const Nucleus_Size inputStringLength = strlen(test->inputString);
+
+        Nucleus_DecimalFloat *decimalFloat;
+        status = Nucleus_DecimalFloat_create_fromString(&decimalFloat, inputString, inputStringLength);
+        if (status) return status;
+
+        // Check if NaN.
+        Nucleus_Boolean isNaN;
+        status = Nucleus_DecimalFloat_isNaN(decimalFloat, &isNaN);
+        if (status) goto End;
+        if (isNaN != test->isNaN) { status = Nucleus_Status_InternalError; goto End; }
+
+        // Check if +Infinity.
+        Nucleus_Boolean isPositiveInfinity;
+        status = Nucleus_DecimalFloat_isPositiveInfinity(decimalFloat, &isPositiveInfinity);
+        if (status) goto End;
+        if (isPositiveInfinity != test->isPositiveInfinity) { status = Nucleus_Status_InternalError; goto End; }
+
+        // Check if -Infinity.
+        Nucleus_Boolean isNegativeInfinity;
+        status = Nucleus_DecimalFloat_isNegativeInfinity(decimalFloat, &isNegativeInfinity);
+        if (status) goto End;
+        if (isNegativeInfinity != test->isNegativeInfinity) { status = Nucleus_Status_InternalError; goto End; }
+
+        // If neither NaN nor Infinity ...
+        if (!isNaN && !isPositiveInfinity && !isNegativeInfinity)
+        {
+            // ... assert the number of digits is proper.
+            if (decimalFloat->numberOfDigits != test->numberOfDigits) { status = Nucleus_Status_InternalError; goto End; }
+            if (decimalFloat->exponent != test->exponent) { status = Nucleus_Status_InternalError; goto End; }
+        }
+
+End:
+        Nucleus_DecimalFloat_destroy(decimalFloat);
+        if (status) break;
+    }
+    return status;
+}
+
+int main(int argc, char **argv)
+{
+    if (test()) return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+}

--- a/test/DecimalInteger/CMakeLists.txt
+++ b/test/DecimalInteger/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) Michael Heilmann 2017, 2018
+
+# Minimum required CMake version.
+cmake_minimum_required(VERSION 3.8)
+
+# Project.
+project (Nucleus.Test.DecimalInteger C)
+message("building Nucleus.Test.DecimalInteger")
+
+if (NUCLEUS_PATH)
+  include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
+  include(${NUCLEUS_PATH}/buildsystem/set_default_project_properties.cmake)
+else()
+  include(${CMAKE_SOURCE_DIR}/buildsystem/detect_compiler_and_platform.cmake)
+  include(${CMAKE_SOURCE_DIR}/buildsystem/set_default_project_properties.cmake)
+endif()
+
+set_project_default_properties()
+
+# Find and configure source files.
+file(GLOB_RECURSE  SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
+# Find and configure header files.
+file(GLOB_RECURSE  HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
+set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
+# Add and configure executable.
+add_executable(Nucleus.Test.DecimalInteger ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(Nucleus.Test.DecimalInteger Nucleus.Library)
+target_include_directories(Nucleus.Test.DecimalInteger PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+# Test.
+add_test(NAME Nucleus.Test.DecimalInteger COMMAND $<TARGET_FILE:Nucleus.Test.DecimalInteger>
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Add.c
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Add.c
@@ -1,0 +1,72 @@
+#include "Nucleus.Test.DecimalInteger/Add.h"
+#include "Nucleus/DecimalInteger.h"
+#include "Nucleus/Types/Integer.h"
+#include "Nucleus/Types/Size.h"
+
+typedef struct Test
+{
+    Nucleus_Integer64 operand1;
+    Nucleus_Integer64 operand2;
+    Nucleus_Integer64 result;
+} Test;
+
+static const Test Tests[] =
+{
+    //
+    {  0,  0,  0 },
+    //
+    {  0,  1,  1 },
+    {  1,  0,  1 },
+    {  1,  1,  2 },
+    //
+    {  0, -1, -1 },
+    { -1,  0, -1 },
+    { -1, -1, -2 },
+    //
+    {  1, -1,  0 },
+    { -1,  1,  0 },
+};
+
+static const Nucleus_Size NumberOfTests = sizeof(Tests) / sizeof(Test);
+
+Nucleus_Status
+testAddition
+    (
+    )
+{
+    Nucleus_Status status = Nucleus_Status_Success;
+    for (Nucleus_Size i = 0, n = NumberOfTests; i < n; ++i)
+    {
+        const Test *test = &(Tests[i]);
+        const int x = test->operand1;
+        const int y = test->operand2;
+        Nucleus_DecimalInteger *dx, *dy;
+
+        status = Nucleus_DecimalInteger_fromInteger64(&dx, x);
+        if (status) return status;
+        status = Nucleus_DecimalInteger_fromInteger64(&dy, y);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(dx);
+            return status;
+        }
+        status = Nucleus_DecimalInteger_add(dx, dy);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(dy);
+            Nucleus_DecimalInteger_destroy(dx);
+            return status;
+        }
+        Nucleus_DecimalInteger *dr;
+        status = Nucleus_DecimalInteger_fromInteger64(&dr, test->result);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(dy);
+            Nucleus_DecimalInteger_destroy(dx);
+            return status;
+        }
+        Nucleus_DecimalInteger_destroy(dy);
+        Nucleus_DecimalInteger_destroy(dx);
+    }
+    return status;
+}

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Add.h
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Add.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Nucleus/Status.h"
+
+Nucleus_Status
+testAddition
+    (
+    );
+

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Compare.c
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Compare.c
@@ -1,0 +1,70 @@
+#include "Nucleus.Test.DecimalInteger/Compare.h"
+#include "Nucleus/DecimalInteger.h"
+#include "Nucleus/Types/Integer.h"
+#include "Nucleus/Types/Size.h"
+
+typedef struct Test
+{
+    Nucleus_Integer64 operand1;
+    Nucleus_Integer64 operand2;
+    Nucleus_Integer result;
+} Test;
+
+static const Test Tests[] =
+{
+    //
+    {  0,   0,  0 },
+    //
+    {  0,   1, -1 },
+    {  1,   0,  1 },
+    {  1,   1,  0 },
+    //
+    {   0, -1,  1 },
+    {  -1,  0, -1 },
+    {  -1, -1,  0 },
+};
+
+static const Nucleus_Size NumberOfTests = sizeof(Tests) / sizeof(Test);
+
+Nucleus_Status
+testComparison
+    (
+    )
+{
+    Nucleus_Status status = Nucleus_Status_Success;
+    for (Nucleus_Size i = 0, n = NumberOfTests; i < n; ++i)
+    {
+        const Test *test = &(Tests[i]);
+
+        // Create operands
+        Nucleus_DecimalInteger *operand1;
+        status = Nucleus_DecimalInteger_fromInteger64(&operand1, test->operand1);
+        if (status) return status;
+        Nucleus_DecimalInteger *operand2;
+        status = Nucleus_DecimalInteger_fromInteger64(&operand2, test->operand2);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(operand1);
+            return status;
+        }
+        // Compare operands.
+        int r;
+        status = Nucleus_DecimalInteger_compare(operand1, operand2, &r);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(operand2);
+            Nucleus_DecimalInteger_destroy(operand1);
+            return status;
+        }
+
+        Nucleus_DecimalInteger_destroy(operand2);
+        Nucleus_DecimalInteger_destroy(operand1);
+
+        if (r != test->result)
+        {
+            status = Nucleus_Status_InternalError;
+            break;
+        }
+    }
+    return status;
+}

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Compare.h
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Compare.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Nucleus/Status.h"
+
+Nucleus_Status
+testComparison
+    (
+    );

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Negate.c
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Negate.c
@@ -1,0 +1,85 @@
+#include "Nucleus.Test.DecimalInteger/Negate.h"
+#include "Nucleus/DecimalInteger.h"
+#include "Nucleus/Types/Integer.h"
+#include "Nucleus/Types/Size.h"
+
+typedef struct Test
+{
+    Nucleus_Integer64 operand;
+    Nucleus_Integer64 result;
+} Test;
+
+static const Test Tests[] =
+{
+    //
+    //{   0,  0 },
+    {   1, -1 },
+    {  -1,  1 },
+};
+
+static const Nucleus_Size NumberOfTests = sizeof(Tests) / sizeof(Test);
+
+Nucleus_Status
+testNegation
+    (
+    )
+{
+    Nucleus_Status status = Nucleus_Status_Success;
+    for (Nucleus_Size i = 0, n = NumberOfTests; i < n; ++i)
+    {
+        const Test *test = &(Tests[i]);
+
+        // Create operand.
+        Nucleus_DecimalInteger *d;
+        status = Nucleus_DecimalInteger_fromInteger64(&d, test->operand);
+        if (status) return status;
+
+        // Clone operand and negate clone.
+        Nucleus_DecimalInteger *nd;
+        status = Nucleus_DecimalInteger_clone(&nd, d);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(d);
+            return status;
+        }
+        status = Nucleus_DecimalInteger_negate(nd);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(nd);
+            Nucleus_DecimalInteger_destroy(d);
+            return status;
+        }
+
+        // Create (expected) result.
+        Nucleus_DecimalInteger *rd;
+        status = Nucleus_DecimalInteger_fromInteger64(&rd, test->result);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(nd);
+            Nucleus_DecimalInteger_destroy(d);
+            return status;
+        }
+
+        // Compare negation and (expected) result.
+        int r;
+        status = Nucleus_DecimalInteger_compare(nd, rd, &r);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(rd);
+            Nucleus_DecimalInteger_destroy(nd);
+            Nucleus_DecimalInteger_destroy(d);
+            return status;
+        }
+
+        Nucleus_DecimalInteger_destroy(rd);
+        Nucleus_DecimalInteger_destroy(nd);
+        Nucleus_DecimalInteger_destroy(d);
+
+        if (r != 0)
+        {
+            status = Nucleus_Status_InternalError;
+            break;
+        }
+    }
+    return status;
+}

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Negate.h
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Negate.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Nucleus/Status.h"
+
+Nucleus_Status
+testNegation
+    (
+    );

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Subtract.c
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Subtract.c
@@ -1,0 +1,69 @@
+#include "Nucleus.Test.DecimalInteger/Subtract.h"
+#include "Nucleus/DecimalInteger.h"
+#include "Nucleus/Types/Integer.h"
+#include "Nucleus/Types/Size.h"
+
+typedef struct Test
+{
+    Nucleus_Integer64 operand1;
+    Nucleus_Integer64 operand2;
+    Nucleus_Integer64 result;
+} Test;
+
+static const Test Tests[] =
+{
+    //
+    {  0, 0,  0 },
+    //
+    {  0, 1, -1 },
+    {  1, 0,  1 },
+    {  1, 1,  0 },
+    //
+    {   0,  -10, -10  },
+    {   0, -999, -999 },
+    {   1, -999, -998 },
+};
+
+static const Nucleus_Size NumberOfTests = sizeof(Tests) / sizeof(Test);
+
+Nucleus_Status
+testSubtraction
+    (
+    )
+{
+    Nucleus_Status status = Nucleus_Status_Success;
+    for (Nucleus_Size i = 0, n = NumberOfTests; i < n; ++i)
+    {
+        const Test *test = &(Tests[i]);
+        const int x = test->operand1;
+        const int y = test->operand2;
+        Nucleus_DecimalInteger *dx, *dy;
+
+        status = Nucleus_DecimalInteger_fromInteger64(&dx, x);
+        if (status) return status;
+        status = Nucleus_DecimalInteger_fromInteger64(&dy, y);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(dx);
+            return status;
+        }
+        status = Nucleus_DecimalInteger_subtract(dx, dy);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(dy);
+            Nucleus_DecimalInteger_destroy(dx);
+            return status;
+        }
+        Nucleus_DecimalInteger *dr;
+        status = Nucleus_DecimalInteger_fromInteger64(&dr, test->result);
+        if (status)
+        {
+            Nucleus_DecimalInteger_destroy(dy);
+            Nucleus_DecimalInteger_destroy(dx);
+            return status;
+        }
+        Nucleus_DecimalInteger_destroy(dy);
+        Nucleus_DecimalInteger_destroy(dx);
+    }
+    return status;
+}

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Subtract.h
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/Subtract.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Nucleus/Status.h"
+
+Nucleus_Status
+testSubtraction
+    (
+    );

--- a/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/main.c
+++ b/test/DecimalInteger/src/Nucleus.Test.DecimalInteger/main.c
@@ -1,0 +1,11 @@
+#include "Nucleus.Test.DecimalInteger/Compare.h"
+#include "Nucleus.Test.DecimalInteger/Add.h"
+#include "Nucleus.Test.DecimalInteger/Subtract.h"
+#include "Nucleus.Test.DecimalInteger/Negate.h"
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    if (testComparison() || testAddition() || testSubtraction()|| testNegation()) return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- Fix and improve documentation
- Replace bool by Nucleus_Boolean and size_t by Nucleus_Size
- Improve project structure
- Update copyright notices in file headers
- Remove deprecated hash functions
- Add Nucleus\_(Single|Double|Quadruple)\_(Least|Greatest),
  Nucleus\_(Single|Double|Quadruple)\_(Positive|Negative)Infinity,
  and Nucleus\_(Single|Double|Quadruple)_NaN
- Add Nucleus_DecimalFloat
- Add Nucleus_DecimalInteger
- Add status code Nucleus_Status_NotAvailable
- Rename Nucleus_safe(Add|Mul) to Nucleus_safe(Add|Mul)Size,
  add Nucleus_safeAddInteger(8|16|32|64)
- Add Nucleus\_[FloatingPointType]\_GreatestExponent[Base] and
  Nucleus\_[FloatingPointType]\_LeastExponent[Base]
- Add Nucleus_cloneMemory and Nucleus_cloneArrayMemory
- Update buildsystem
  - Add support for MinGW
  - Add option to choose between static and dynamic runtimes when
    using MinGW or MSVC