### PR TITLE
Update Nucleus

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build:
     project: nucleus.sln            # path to Visual Studio solution or project
 
 test_script:
-    - ctest -VV -C "%CONFIGURATION%" 
+    - ctest --output-on-failure --extra-verbose --build-config "%CONFIGURATION%" 
 
 # if one matrix entry fails, all entries fails
 # https://www.appveyor.com/docs/build-configuration#failing-strategy

--- a/buildsystem/templates.cmake
+++ b/buildsystem/templates.cmake
@@ -74,7 +74,6 @@ macro(define_module module_name)
   # Enable testing.
   include(CTest)
   enable_testing()
-  set(CTEST_OUTPUT_ON_FAILURE ON)
 
   # If with optimizations is not specified ...
   if (NOT DEFINED ${module_name}-With-Optimizations)
@@ -194,4 +193,5 @@ macro(define_dynamic_library parent_project_name project_name libraries language
                           LIBRARY_OUTPUT_DIRECTORY
 						  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
   endif()
+  set_target_properties(${project_name} PROPERTIES PREFIX "")
 endmacro()


### PR DESCRIPTION
- build system: Remove 'cyg' library prefix from the naes of
  "dynamically loadable libraries" under Cygwin.
- AppVeyor CI: Print the output written by a test iff the test fails.