### PR TITLE
Update Nucleus

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The following annotations are currently available.
 - [Nucleus_NoReturn](documentation/Nucleus_NoReturn.md)
 - [Nucleus_Likely](documentation/Nucleus_Likely.md)
 - [Nucleus_Unlikely](documentation/Nucleus_Unlikely.md)
+- [Nucleus_AlwaysFail](documentation/Nucleus_AlwaysFail.md)
+- [Nucleus_AlwaysSucceed](documentation/Nucleus_AlwaysSucceed.md)
 
 ### Nucleus Memory Module
 The Nucleus Memory Module provides functionality to allocate and deallocate memory blocks, as well as valuation and manipulation of memory blocks and their contents.

--- a/documentation/Nucleus_AlwaysFail.md
+++ b/documentation/Nucleus_AlwaysFail.md
@@ -1,0 +1,18 @@
+# `Nucleus_AlwaysFail`
+*Function annotation indicating that a function always fails.*
+
+## C Signature
+```
+#define Nucleus_AlwaysFail() /* hidden */
+```
+
+## Description
+Functions in Nucleus always return a status code indicating success or failure.
+This annotation indicates that a function will always return a status code indicating failure.
+
+## Requirements
+
+|                      | Windows                  | Linux                     |
+|----------------------|--------------------------|---------------------------|
+| *Header*             | `Nucleus/Annotations.h`  | `Nucleus/Annotations.h`   |
+| *Static library*     |          -               |           -               |

--- a/documentation/Nucleus_AlwaysSucceed.md
+++ b/documentation/Nucleus_AlwaysSucceed.md
@@ -1,0 +1,18 @@
+# `Nucleus_AlwaysSucceed`
+*Function annotation indicating that a function always succeeds.*
+
+## C Signature
+```
+#define Nucleus_AlwaysSucceed() /* hidden */
+```
+
+## Description
+Functions in Nucleus always return a status code indicating success or failure.
+This annotation indicates that a function will always return a status code indicating success.
+
+## Requirements
+
+|                      | Windows                  | Linux                     |
+|----------------------|--------------------------|---------------------------|
+| *Header*             | `Nucleus/Annotations.h`  | `Nucleus/Annotations.h`   |
+| *Static library*     |          -               |           -               |

--- a/library/src/Nucleus/Annotations.h
+++ b/library/src/Nucleus/Annotations.h
@@ -11,7 +11,7 @@
 /// @brief A function annotation indicating that the function never raises an error.
 #define Nucleus_NoError()
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_NonNull.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_NonNull.md
 #if ((Nucleus_C_Compiler == Nucleus_C_Compiler_GCC) || (Nucleus_C_Compiler == Nucleus_C_Compiler_Clang)) \
     && !defined(DOXYGEN)
     #define Nucleus_NonNull(...) __attribute__ ((nonnull(__VA_ARGS__))) /**< @hideinitializer */
@@ -27,7 +27,7 @@
     #define Nucleus_ReturnNonNull()
 #endif
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_NoReturn.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_NoReturn.md
 #if ((Nucleus_C_Compiler == Nucleus_C_Compiler_GCC) || (Nucleus_C_Compiler == Nucleus_C_Compiler_Clang)) \
     && !defined(DOXYGEN)
     #define Nucleus_NoReturn() __attribute__ ((noreturn)) /**< @hideinitializer */
@@ -81,7 +81,13 @@
 /// @param parameter the parameter declaration
 #define Nucleus_OutputInputParameter(parameter) parameter /**< @hideinitializer */
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Likely.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_AlwaysSucceed.md
+#define Nucleus_AlwaysSucceed()
+
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_AlwaysFail.md
+#define Nucleus_AlwaysFail()
+
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Likely.md
 #if ((Nucleus_C_Compiler == Nucleus_C_Compler_GCC) || (Nucleus_C_Compiler == Nucleus_C_Compiler_Clang)) \
     && !defined(DOXYGEN)
     #define Nucleus_Likely(expression) (__builtin_expect((expression) ? 1 : 0, 1)) /**< @hideinitializer */
@@ -89,7 +95,7 @@
     #define Nucleus_Likely(expression) (expression) /**< @hideinitializer */
 #endif
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Unlikely.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Unlikely.md
 #if ((Nucleus_C_Compiler == Nucleus_C_Compiler_GCC) || (Nucleus_C_Compiler == Nucleus_C_Compiler_Clang)) \
     && !defined(DOXYGEN)
     #define Nucleus_Unlikely(expression) (__builtin_expect((expression) ? 1 : 0, 0)) /**< @hideinitializer */

--- a/library/src/Nucleus/Collections/ByteArray.c
+++ b/library/src/Nucleus/Collections/ByteArray.c
@@ -105,7 +105,7 @@ Nucleus_Collections_ByteArray_prependMany
         
         Nucleus_Collections_ByteArray *dynamicByteArray,
         const char *bytes,
-        size_t numberOfBytes
+        Nucleus_Size numberOfBytes
     )
 {
     if (Nucleus_Unlikely(!dynamicByteArray)) return Nucleus_Status_InvalidArgument;
@@ -169,7 +169,7 @@ Nucleus_Collections_ByteArray_lock
     (
         Nucleus_Collections_ByteArray *byteArray,
         void **bytes,
-        size_t *numberOfBytes
+        Nucleus_Size *numberOfBytes
     )
 {
     *bytes = byteArray->array;

--- a/library/src/Nucleus/Collections/ByteArray.h
+++ b/library/src/Nucleus/Collections/ByteArray.h
@@ -18,7 +18,7 @@ struct Nucleus_Collections_ByteArray
     Nucleus_Size size;
 }; // struct Nucleus_Collections_ByteArray
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_ByteArray_initialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_ByteArray_initialize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_initialize
     (
@@ -26,14 +26,14 @@ Nucleus_Collections_ByteArray_initialize
         Nucleus_Size initialCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_ByteArray_uninitialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_ByteArray_uninitialize.md
 Nucleus_NonNull() void
 Nucleus_Collections_ByteArray_uninitialize
     (
         Nucleus_Collections_ByteArray *byteArray
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_increaseCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_increaseCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_increaseCapacity
     (
@@ -41,7 +41,7 @@ Nucleus_Collections_ByteArray_increaseCapacity
         Nucleus_Size requiredAdditionalCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_ensureFreeCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_ensureFreeCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_ensureFreeCapacity
     (
@@ -49,7 +49,7 @@ Nucleus_Collections_ByteArray_ensureFreeCapacity
         Nucleus_Size requiredFreeCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_append.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_append.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_append
     (
@@ -57,16 +57,16 @@ Nucleus_Collections_ByteArray_append
         char byte
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_ByteArray_appendMany.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_ByteArray_appendMany.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_appendMany
     (
         Nucleus_Collections_ByteArray *byteArray,
         const char *bytes,
-        size_t numberOfBytes
+        Nucleus_Size numberOfBytes
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_prepend.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_prepend.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_prepend
     (
@@ -74,7 +74,7 @@ Nucleus_Collections_ByteArray_prepend
         char byte
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_ByteArray_prependMany.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_ByteArray_prependMany.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_prependMany
     (
@@ -83,7 +83,7 @@ Nucleus_Collections_ByteArray_prependMany
         Nucleus_Size numberOfBytes
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_insert.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_insert.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_insert
     (
@@ -92,7 +92,7 @@ Nucleus_Collections_ByteArray_insert
         Nucleus_Size index
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_ByteArray_insertMany.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_ByteArray_insertMany.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_insertMany
     (
@@ -102,7 +102,7 @@ Nucleus_Collections_ByteArray_insertMany
         Nucleus_Size index
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_at.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_at.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_at
     (
@@ -125,7 +125,7 @@ Nucleus_Collections_ByteArray_unlock
         Nucleus_Collections_ByteArray *byteArray
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getSize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getSize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_getSize
     (
@@ -133,7 +133,7 @@ Nucleus_Collections_ByteArray_getSize
         Nucleus_Size *size
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_getCapacity
     (
@@ -141,7 +141,7 @@ Nucleus_Collections_ByteArray_getCapacity
         Nucleus_Size *capacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getFreeCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getFreeCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_getFreeCapacity
     (
@@ -149,7 +149,7 @@ Nucleus_Collections_ByteArray_getFreeCapacity
         Nucleus_Size *freeCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_clear.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_clear.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_ByteArray_clear
     (

--- a/library/src/Nucleus/Collections/Callbacks.h
+++ b/library/src/Nucleus/Collections/Callbacks.h
@@ -1,8 +1,13 @@
 // Copyright (c) 2018 Michael Heilmann
 #pragma once
 
+
+
+
 #include "Nucleus/Status.h"
-#include <stdbool.h> // For bool, true, false.
+#include "Nucleus/Types/Boolean.h"
+#include "Nucleus/Types/HashValue.h"
+#include "Nucleus/Types/Size.h"
 
 
 
@@ -14,7 +19,8 @@
 /// @brief A "lock" callback.
 /// @param object a pointer to an opaque object, the object to be locked
 /// @remark The caller must ensure that @a is passed a proper value.
-typedef void Nucleus_LockFunction(void *object);
+/// @return A "lock" callback always returns #Nucleus_Status_Success.
+typedef Nucleus_Status Nucleus_LockFunction(void *object);
 
 
 
@@ -26,7 +32,8 @@ typedef void Nucleus_LockFunction(void *object);
 /// @brief An "unlock" callback.
 /// @param object a pointer to an opaque object, the object to be unlocked
 /// @remark The caller must ensure that @a is passed a proper value.
-typedef void Nucleus_UnlockFunction(void *object);
+/// @return An "unlock" function always returns #Nucleus_Status_Success.
+typedef Nucleus_Status Nucleus_UnlockFunction(void *object);
 
 
 
@@ -37,7 +44,9 @@ typedef void Nucleus_UnlockFunction(void *object);
 
 /// @brief A "hash" callback.
 /// @param a pointer to the object to be hashed.
-typedef Nucleus_Status Nucleus_HashFunction(void *, unsigned int *);
+/// @param [out] hashValue a pointer to a @a (Nucleus_HashValue) variable 
+/// @return #Nucleus_Status_Success on success a non-zero status code on failure
+typedef Nucleus_Status Nucleus_HashFunction(void *object, Nucleus_HashValue *hashValue);
 
 
 
@@ -46,7 +55,8 @@ typedef Nucleus_Status Nucleus_HashFunction(void *, unsigned int *);
 /// @param pointer the pointer
 #define NUCLEUS_EQUALTOFUNCTION(pointer) ((Nucleus_EqualToFunction *)(pointer))
 
-/// @brief An "equalTo" callback.
+/// @brief An "equal to" callback.
 /// @param left, right pointers to the objects to be compared
-/// @param [out] equal a pointer to a @a bool variable
-typedef Nucleus_Status Nucleus_EqualToFunction(void *, void *, bool *);
+/// @param [out] equalTo a pointer to a @a (Nucleus_Boolean) variable
+/// @return #Nucleus_Status_Success on success a non-zero status code on failure
+typedef Nucleus_Status Nucleus_EqualToFunction(void *left, void *right, Nucleus_Boolean *equalTo);

--- a/library/src/Nucleus/Collections/PointerArray.c
+++ b/library/src/Nucleus/Collections/PointerArray.c
@@ -9,7 +9,7 @@ Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerArray_initialize
     (
         Nucleus_Collections_PointerArray *dynamicPointerArray,
-        size_t initialCapacity,
+        Nucleus_Size initialCapacity,
         Nucleus_LockFunction *lockFunction,
         Nucleus_UnlockFunction *unlockFunction
     )
@@ -141,7 +141,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_at
     (
         Nucleus_Collections_PointerArray *dynamicPointerArray,
-        size_t index,
+        Nucleus_Size index,
         void **pointer
     )
 {
@@ -155,7 +155,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_getSize
     (
         Nucleus_Collections_PointerArray *dynamicPointerArray,
-        size_t *size
+        Nucleus_Size *size
     )
 {
     if (Nucleus_Unlikely(!dynamicPointerArray || !size)) return Nucleus_Status_InvalidArgument;
@@ -179,7 +179,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_getFreeCapacity
     (
         Nucleus_Collections_PointerArray *dynamicPointerArray,
-        size_t *freeCapacity
+        Nucleus_Size *freeCapacity
     )
 {
     if (Nucleus_Unlikely(!dynamicPointerArray || !freeCapacity)) return Nucleus_Status_InvalidArgument;

--- a/library/src/Nucleus/Collections/PointerArray.h
+++ b/library/src/Nucleus/Collections/PointerArray.h
@@ -13,16 +13,16 @@ struct Nucleus_Collections_PointerArray
     /// @brief A pointer to an array of @a capacity @a (void *) elements.
     void **elements;
     /// @brief The capacity, in elements, of the array pointed to by @a array.
-    size_t capacity;
+    Nucleus_Size capacity;
     /// @brief The number of elements in this array.
-    size_t size;
+    Nucleus_Size size;
     /// @brief A pointer to the @a Nucleus_LockFunction function or a null pointer.
     Nucleus_LockFunction *lockFunction;
     /// @brief A pointer to the @a Nucleus_UnlockFunction function or  a null pointer.
     Nucleus_UnlockFunction *unlockFunction;
 }; // struct Nucleus_Collections_PointerArray
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_PointerArray_initialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_PointerArray_initialize.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerArray_initialize
     (
@@ -32,14 +32,14 @@ Nucleus_Collections_PointerArray_initialize
         Nucleus_UnlockFunction *unlockFunction
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_PointerArray_uninitialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_PointerArray_uninitialize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_uninitialize
     (
         Nucleus_Collections_PointerArray *dynamicPointerArray
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_increaseCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_increaseCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_increaseCapacity
     (
@@ -47,7 +47,7 @@ Nucleus_Collections_PointerArray_increaseCapacity
         Nucleus_Size requiredAdditionalCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_ensureFreeCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_ensureFreeCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_ensureFreeCapacity
     (
@@ -55,7 +55,7 @@ Nucleus_Collections_PointerArray_ensureFreeCapacity
         Nucleus_Size requiredFreeCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_append.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_append.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerArray_append
     (
@@ -63,7 +63,7 @@ Nucleus_Collections_PointerArray_append
         void *pointer
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_prepend.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_prepend.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerArray_prepend
     (
@@ -71,7 +71,7 @@ Nucleus_Collections_PointerArray_prepend
         void *pointer
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_insert.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_insert.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerArray_insert
     (
@@ -80,7 +80,7 @@ Nucleus_Collections_PointerArray_insert
         Nucleus_Size index
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_at.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_at.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_at
     (
@@ -89,7 +89,7 @@ Nucleus_Collections_PointerArray_at
         void **pointer
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getSize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getSize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_getSize
     (
@@ -97,7 +97,7 @@ Nucleus_Collections_PointerArray_getSize
         Nucleus_Size *size
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_getCapacity
     (
@@ -105,7 +105,7 @@ Nucleus_Collections_PointerArray_getCapacity
         Nucleus_Size *capacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getFreeCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getFreeCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_getFreeCapacity
     (
@@ -113,7 +113,7 @@ Nucleus_Collections_PointerArray_getFreeCapacity
         Nucleus_Size *freeCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_clear.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_clear.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerArray_clear
     (

--- a/library/src/Nucleus/Collections/PointerDeque.h
+++ b/library/src/Nucleus/Collections/PointerDeque.h
@@ -3,7 +3,7 @@
 
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Collections/Callbacks.h"
-#include <stddef.h> // For size_t.
+#include "Nucleus/Types/Size.h"
 
 /// @brief A dynamic array of pointers.
 typedef struct Nucleus_Collections_PointerDeque Nucleus_Collections_PointerDeque;
@@ -13,28 +13,28 @@ struct Nucleus_Collections_PointerDeque
     /// @brief A pointer to an array of @a capacity @a (void *) elements.
     void **elements;
     /// @brief The capacity, in elements, of the array pointed to by @a array.
-    size_t capacity;
+    Nucleus_Size capacity;
     /// @brief The position to read from.
-    size_t read;
+    Nucleus_Size read;
     /// @brief The number of elements in this array.
-    size_t size;
+    Nucleus_Size size;
     /// @brief A pointer to the @a Nucleus_LockFunction function or a null pointer.
     Nucleus_LockFunction *lockFunction;
     /// @brief A pointer to the @a Nucleus_UnlockFunction function or  a null pointer.
     Nucleus_UnlockFunction *unlockFunction;
 }; // struct Nucleus_Collections_PointerDeque
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_PointerDeque_initialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_PointerDeque_initialize.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerDeque_initialize
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t initialCapacity,
+        Nucleus_Size initialCapacity,
         Nucleus_LockFunction *lockFunction,
         Nucleus_UnlockFunction *unlockFunction
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_PointerDeque_uninitialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_PointerDeque_uninitialize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_uninitialize
     (
@@ -43,54 +43,54 @@ Nucleus_Collections_PointerDeque_uninitialize
 
 // TODO: Nucleus_Collections_ByteArray and Nucleus_Collections_PointerArray shall provide this function as well.
 // TODO: This function shall be documented in
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_increaseCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_increaseCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_increaseCapacity
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t requiredAdditionalCapacity
+        Nucleus_Size requiredAdditionalCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_ensureFreeCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_ensureFreeCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_ensureFreeCapacity
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t requiredFreeCapacity
+        Nucleus_Size requiredFreeCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getSize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_getSize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_getSize
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t *size
+        Nucleus_Size *size
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_getCapacity
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t *capacity
+        Nucleus_Size *capacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getFreeCapacity.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_getFreeCapacity.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_getFreeCapacity
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t *freeCapacity
+        Nucleus_Size *freeCapacity
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Collection-Type]_clear.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Collection-Type]_clear.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_clear
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_append.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_append.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerDeque_append
     (
@@ -98,7 +98,7 @@ Nucleus_Collections_PointerDeque_append
         void *pointer
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_prepend.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_prepend.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerDeque_prepend
     (
@@ -106,21 +106,21 @@ Nucleus_Collections_PointerDeque_prepend
         void *pointer
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_insert.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_insert.md
 Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerDeque_insert
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
         void *pointer,
-        size_t index
+        Nucleus_Size index
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_at.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_[Array-Collection-Type]_at.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerDeque_at
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t index,
+        Nucleus_Size index,
         void **element
     );
 
@@ -128,5 +128,5 @@ Nucleus_NonNull(1) Nucleus_Status
 Nucleus_Collections_PointerDeque_remove
     (
         Nucleus_Collections_PointerDeque *dynamicPointerDeque,
-        size_t index
+        Nucleus_Size index
     );

--- a/library/src/Nucleus/Collections/PointerHashMap-private.c.i
+++ b/library/src/Nucleus/Collections/PointerHashMap-private.c.i
@@ -16,7 +16,7 @@ getPosition
     for (Nucleus_Collections_PointerHashMap_Node *node = dynamicPointerHashMap->buckets[position->hashIndex];
          NULL != node; node = node->next)
     {
-        bool equalTo;
+        Nucleus_Boolean equalTo;
         dynamicPointerHashMap->keyEqualToKeyFunction(key, node->key, &equalTo);
         if (equalTo)
         {
@@ -33,7 +33,7 @@ clear
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap
     )
 {
-    for (size_t i = 0, n = dynamicPointerHashMap->capacity; i < n; ++i)
+    for (Nucleus_Size i = 0, n = dynamicPointerHashMap->capacity; i < n; ++i)
     {
         Nucleus_Collections_PointerHashMap_Node **bucket = &(dynamicPointerHashMap->buckets[i]);
         while (*bucket)

--- a/library/src/Nucleus/Collections/PointerHashMap-private.h.i
+++ b/library/src/Nucleus/Collections/PointerHashMap-private.h.i
@@ -3,20 +3,21 @@
 
 #include "Nucleus/Collections/PointerHashMap.h"
 #include "Nucleus/Memory.h"
+#include "Nucleus/Types/HashValue.h"
 
 struct Nucleus_Collections_PointerHashMap_Node
 {
     Nucleus_Collections_PointerHashMap_Node *next;
     void *key;
-    size_t hashValue;
+    Nucleus_HashValue hashValue;
     void *value;
 }; // struct Nucleus_Collections_PointerHashMap_Node
 
 typedef struct Position
 {
     Nucleus_Collections_PointerHashMap_Node *node; // Pointer to the colliding node or a null pointer.
-    unsigned int hashValue; // The hash value.
-    unsigned int hashIndex; // The hash index.
+    Nucleus_HashValue hashValue; // The hash value.
+    Nucleus_Size hashIndex; // The hash index.
 } Position;
 
 Nucleus_NonNull() static Nucleus_Status 

--- a/library/src/Nucleus/Collections/PointerHashMap.c
+++ b/library/src/Nucleus/Collections/PointerHashMap.c
@@ -5,7 +5,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerHashMap_initialize
     (
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap,
-        size_t initialCapacity,
+        Nucleus_Size initialCapacity,
         Nucleus_LockFunction *lockKeyFunction,
         Nucleus_UnlockFunction *unlockKeyFunction,
         Nucleus_HashFunction *hashKeyFunction,
@@ -22,7 +22,7 @@ Nucleus_Collections_PointerHashMap_initialize
                                                         initialCapacity,
                                                         sizeof(Nucleus_Collections_PointerHashMap_Node *));
     if (Nucleus_Unlikely(status)) return status;
-    for (size_t i = 0, n = initialCapacity; i < n; ++i)
+    for (Nucleus_Size i = 0, n = initialCapacity; i < n; ++i)
     {
         dynamicPointerHashMap->buckets[i] = NULL;
     }
@@ -42,7 +42,7 @@ Nucleus_Collections_PointerHashMap_initialize
     return Nucleus_Status_Success;
 }
 
-Nucleus_NonNull() void
+Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerHashMap_uninitialize
     (
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap
@@ -60,6 +60,7 @@ Nucleus_Collections_PointerHashMap_uninitialize
         dynamicPointerHashMap->unused = node->next;
         Nucleus_deallocateMemory(node);
     }
+    return Nucleus_Status_Success;
 }
 
 Nucleus_NonNull(1) Nucleus_Status
@@ -68,7 +69,7 @@ Nucleus_Collections_PointerHashMap_set
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap,
         void *key,
         void *value,
-        bool replace
+        Nucleus_Boolean replace
     )
 {
     Position position;
@@ -142,4 +143,3 @@ Nucleus_Collections_PointerHashMap_clear
     clear(dynamicPointerHashMap);
     return Nucleus_Status_Success;
 }
-

--- a/library/src/Nucleus/Collections/PointerHashMap.h
+++ b/library/src/Nucleus/Collections/PointerHashMap.h
@@ -3,7 +3,8 @@
 
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Collections/Callbacks.h"
-#include <stddef.h> // For size_t.
+#include "Nucleus/Types/Boolean.h"
+#include "Nucleus/Types/Size.h"
 
 typedef struct Nucleus_Collections_PointerHashMap_Node Nucleus_Collections_PointerHashMap_Node;
 
@@ -11,7 +12,7 @@ typedef struct Nucleus_Collections_PointerHashMap Nucleus_Collections_PointerHas
 struct Nucleus_Collections_PointerHashMap
 {
     Nucleus_Collections_PointerHashMap_Node **buckets;
-    size_t size, capacity;
+    Nucleus_Size size, capacity;
     Nucleus_Collections_PointerHashMap_Node *unused;
 
     Nucleus_LockFunction *lockKeyFunction;
@@ -24,12 +25,12 @@ struct Nucleus_Collections_PointerHashMap
 
 }; // struct Nucleus_Collections_PointerHashMap
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_PointerHashMap_initialize.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_PointerHashMap_initialize.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerHashMap_initialize
     (
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap,
-        size_t initialCapacity,
+        Nucleus_Size initialCapacity,
         Nucleus_LockFunction *lockKeyFunction,
         Nucleus_UnlockFunction *unlockKeyFunction,
         Nucleus_HashFunction *hashKeyFunction,
@@ -38,8 +39,8 @@ Nucleus_Collections_PointerHashMap_initialize
         Nucleus_UnlockFunction *unlockValueFunction
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_Collections_PointerHashMap_uninitialize.md
-Nucleus_NonNull() void
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_Collections_PointerHashMap_uninitialize.md
+Nucleus_NonNull() Nucleus_Status
 Nucleus_Collections_PointerHashMap_uninitialize
     (
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap
@@ -51,7 +52,7 @@ Nucleus_Collections_PointerHashMap_set
         Nucleus_Collections_PointerHashMap *dynamicPointerHashMap,
         void *key,
         void *value,
-        bool replace
+        Nucleus_Boolean replace
     );
 
 Nucleus_NonNull() Nucleus_Status

--- a/library/src/Nucleus/CommandLine/CommandLine-private.h.i
+++ b/library/src/Nucleus/CommandLine/CommandLine-private.h.i
@@ -38,7 +38,7 @@ ParameterList_initialize
         ParameterList *parameterList
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 ParameterList_uninitialize
     (
         ParameterList *parameterList
@@ -55,7 +55,7 @@ Nucleus_NonNull() static Nucleus_Status
 ParameterList_getSize
     (
         ParameterList *parameterList,
-        size_t *size
+        Nucleus_Size *size
     );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +67,7 @@ Nucleus_NonNull() static Nucleus_Status
 hashFunction
     (
         const char *p,
-        unsigned int *hv
+        Nucleus_HashValue *hashValue
     );
 
 Nucleus_NonNull() static Nucleus_Status
@@ -75,7 +75,7 @@ equalToFunction
     (
         const char *p,
         const char *q,
-        bool *r
+        Nucleus_Boolean *equalTo
     );
 
 Nucleus_NonNull() static Nucleus_Status
@@ -84,7 +84,7 @@ OptionSet_initialize
         OptionSet *optionSet
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 OptionSet_uninitialize
     (
         OptionSet *optionSet
@@ -120,7 +120,7 @@ initializeCommand
         Nucleus_CommandLine_Command *command
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 uninitializeCommand
     (
         Nucleus_CommandLine_Command *command
@@ -132,7 +132,7 @@ createCommand
         Nucleus_CommandLine_Command **command
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 destroyCommand
     (
         Nucleus_CommandLine_Command *command
@@ -153,7 +153,7 @@ createOption
         const char *optionName
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 destroyOption
     (
         Nucleus_CommandLine_Option *option
@@ -173,13 +173,13 @@ createParameter
         const char *parameterValue
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 uninitializeParameter
     (
         Nucleus_CommandLine_Parameter *parameter
     );
 
-Nucleus_NonNull() static void
+Nucleus_NonNull() static Nucleus_Status
 destroyParameter
     (
         Nucleus_CommandLine_Parameter *parameter

--- a/library/src/Nucleus/CommandLine/CommandLine.c
+++ b/library/src/Nucleus/CommandLine/CommandLine.c
@@ -44,7 +44,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_CommandLine_Command_getParameterCount
     (
         Nucleus_CommandLine_Command *command,
-        size_t *parameterCount
+        Nucleus_Size *parameterCount
     )
 {
     if (!command) return Nucleus_Status_InvalidArgument;
@@ -55,7 +55,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_CommandLine_Option_getParameterCount
     (
         Nucleus_CommandLine_Option *option,
-        size_t *parameterCount
+        Nucleus_Size *parameterCount
     )
 {
     if (!option) return Nucleus_Status_InvalidArgument;

--- a/library/src/Nucleus/CommandLine/CommandLine.h
+++ b/library/src/Nucleus/CommandLine/CommandLine.h
@@ -11,7 +11,7 @@
 
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
-#include <stddef.h> // For size_t.
+#include "Nucleus/Types/Size.h"
 
 typedef struct Nucleus_CommandLine_Parameter Nucleus_CommandLine_Parameter;
 typedef struct Nucleus_CommandLine_Option Nucleus_CommandLine_Option;
@@ -61,7 +61,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_CommandLine_Command_getParameterCount
     (
         Nucleus_CommandLine_Command *command,
-        size_t *parameterCount
+        Nucleus_Size *parameterCount
     );
 
 /// @brief Get the number of parameters of a @a (Nucleus_CommandLine_Option) object.
@@ -72,7 +72,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_CommandLine_Option_getParameterCount
     (
         Nucleus_CommandLine_Option *option,
-        size_t *parameterCount
+        Nucleus_Size *parameterCount
     );
 
 // i-th parameter
@@ -80,7 +80,7 @@ Nucleus_NonNull() Nucleus_Status
 Nucleus_CommandLine_Command_getParameter
     (
         Nucleus_CommandLine_Command *command,
-        size_t index,
+        Nucleus_Size index,
         Nucleus_CommandLine_Parameter **parameter
     );
 

--- a/library/src/Nucleus/Conversion/stringToBoolean.c
+++ b/library/src/Nucleus/Conversion/stringToBoolean.c
@@ -17,7 +17,7 @@ Nucleus_stringToBoolean
         case sizeof("true") - sizeof(char):
         {
             Nucleus_Status status;
-            bool equal;
+            Nucleus_Boolean equal;
             status = Nucleus_compareMemory(bytes, "true", sizeof("true") - sizeof(char), &equal);
             if (status) return status;
             *value = Nucleus_Boolean_True;

--- a/library/src/Nucleus/FileSystem/FileHandleInterface.h
+++ b/library/src/Nucleus/FileSystem/FileHandleInterface.h
@@ -10,10 +10,7 @@
 #include "Nucleus/FileSystem/NonExistingFilePolicy.h"
 #include "Nucleus/FileSystem/ExistingFilePolicy.h"
 #include "Nucleus/FileSystem/FileAccessMode.h"
-
-// For size_t.
-// TODO: Remove this. Use Nucleus_Size.
-#include <stdlib.h>
+#include "Nucleus/Types/Size.h"
 
 /// @ingroup filesystem
 /// @brief The opaque type of a file handle.
@@ -48,7 +45,7 @@ Nucleus_FileHandle_destroy
 /// @ingroup filesystem
 /// @brief Get the size of thefi
 /// @param fileHandle a pointer to a @a (Nucleus_FileHandle) object
-/// @param fileSize a pointer to a @a (size_t) variable
+/// @param fileSize a pointer to a @a (Nucleus_Size) variable
 /// @defaultReturn
 /// @success The size of the file represented by the @a (Nucleu_FileHandle) object pointed to by @a (fileHandle) was assigned to @a (*fileSize).
 /// @failure @a (*fileSize) was not dereferenced.
@@ -56,5 +53,5 @@ Nucleus_NonNull(1, 2) Nucleus_Status
 Nucleus_FileHandle_getFileSize
     (
         Nucleus_FileHandle *fileHandle,
-        size_t *fileSize
+        Nucleus_Size *fileSize
     );

--- a/library/src/Nucleus/FileSystem/FileHandleLinux.c
+++ b/library/src/Nucleus/FileSystem/FileHandleLinux.c
@@ -86,7 +86,7 @@ Nucleus_FileHandle_create
           0 },
         };
     const PolicyMapping *policyMapping = NULL;
-    for (size_t i = 0, n = sizeof(policyMappings) / sizeof(PolicyMapping); i < n; ++i)
+    for (Nucleus_Size i = 0, n = sizeof(policyMappings) / sizeof(PolicyMapping); i < n; ++i)
     {
         policyMapping = policyMappings + i;
         if (policyMapping->existingFilePolicy == existingFilePolicy &&
@@ -145,10 +145,10 @@ Nucleus_NonNull(1,2) Nucleus_Status
 Nucleus_FileHandle_getFileSize
     (
         Nucleus_FileHandle *fileHandle,
-        size_t *fileSize
+        Nucleus_Size *fileSize
     )
 {
-    if (!fileHandle || !fileSize || fileHandle->fileDescriptor < 0)
+    if (Nucleus_Unlikely(!fileHandle || !fileSize || fileHandle->fileDescriptor < 0))
     {
         return Nucleus_Status_InvalidArgument;
     }
@@ -159,7 +159,7 @@ Nucleus_FileHandle_getFileSize
     {
         return Nucleus_Status_EnvironmentFailed;
     }
-    *fileSize = (size_t)stat_buf.st_size;
+    *fileSize = (Nucleus_Size)stat_buf.st_size;
     return Nucleus_Status_Success;
 }
 

--- a/library/src/Nucleus/FileSystem/FileHandleWindows.c
+++ b/library/src/Nucleus/FileSystem/FileHandleWindows.c
@@ -77,7 +77,7 @@ Nucleus_FileHandle_create
           0 },
         };
     const PolicyMapping *policyMapping = NULL;
-    for (size_t i = 0, n = sizeof(policyMappings) / sizeof(PolicyMapping); i < n; ++i)
+    for (Nucleus_Size i = 0, n = sizeof(policyMappings) / sizeof(PolicyMapping); i < n; ++i)
     {
         policyMapping = policyMappings + i;
         if (policyMapping->existingFilePolicy == existingFilePolicy &&

--- a/library/src/Nucleus/FileSystem/getFileContentsInterface.h
+++ b/library/src/Nucleus/FileSystem/getFileContentsInterface.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
+#include "Nucleus/Types/Size.h"
 
 /// @ingroup filesystem
 /// @brief The type of a callback invoked by Nucleus_getFileContentsExtended function.
@@ -22,14 +23,14 @@ Nucleus_getFileContentsExtendedCallbackFunction
     (
         Nucleus_InputOutputParameter(void *object),
         Nucleus_InputParameter(const char *bytes),
-        Nucleus_InputParameter(size_t numberOfBytes)
+        Nucleus_InputParameter(Nucleus_Size numberOfBytes)
     );
 
 /// @ingroup filesystem
 /// @brief Get the contents of a file.
 /// @param pathname a pointer to the pathname of the file
 /// @param bytes a pointer to a @a (char *) variable
-/// @param numberOfBytes a pointer to a @a (size_t) variable
+/// @param numberOfBytes a pointer to a @a (Nucleus_Size) variable
 /// @defaultReturn
 /// @success @a *numberOfBytes was assigned the size of the file which may be @a 0.
 ///          @a *bytes was assigned a pointer to an array of at least @a *numberOfBytes Bytes such that the first @a *numberOfBytes
@@ -41,7 +42,7 @@ Nucleus_getFileContents
     (
         Nucleus_InputParameter(const char *pathname),
         Nucleus_OutputParameter(char **bytes),
-        Nucleus_OutputParameter(size_t *numberOfBytes)
+        Nucleus_OutputParameter(Nucleus_Size *numberOfBytes)
     );
 
 /// @ingroup filesystem

--- a/library/src/Nucleus/FileSystem/getFileContentsLinux.c
+++ b/library/src/Nucleus/FileSystem/getFileContentsLinux.c
@@ -23,7 +23,7 @@
 typedef struct Nucleus_FileMapping
 {
     char *bytes;
-    size_t numberOfBytes;
+    Nucleus_Size numberOfBytes;
     Nucleus_FileHandle *fileHandle;
 } Nucleus_FileMapping;
 
@@ -109,11 +109,11 @@ Nucleus_getFileContents
     (
         Nucleus_InputParameter(const char *pathname),
         Nucleus_OutputParameter(char **bytes),
-        Nucleus_OutputParameter(size_t *numberOfBytes)
+        Nucleus_OutputParameter(Nucleus_Size *numberOfBytes)
     )
 {
     // Validate arguments.
-    if (!bytes || !numberOfBytes)
+    if (Nucleus_Unlikely(!bytes || !numberOfBytes))
     {
         fprintf(stderr, "invalid arguments\n");
         return Nucleus_Status_InvalidArgument;

--- a/library/src/Nucleus/FileSystem/getFileContentsWindows.c
+++ b/library/src/Nucleus/FileSystem/getFileContentsWindows.c
@@ -16,13 +16,13 @@
 /// @internal
 /// @brief Get the size of a file.
 /// @param fileDescriptor a file descriptor
-/// @param fileSize a pointer to a @a (size_t) variable
+/// @param fileSize a pointer to a @a (Nucleus_Size) variable
 /// @defaultReturn
 static Nucleus_NonNull(1, 2) Nucleus_Status
 Nucleus_getFileSize
     (
         HANDLE hFile,
-        size_t *fileSize
+        Nucleus_Size *fileSize
     )
 {
     if (INVALID_HANDLE_VALUE == hFile)

--- a/library/src/Nucleus/FileSystem/setFileContentsInterface.h
+++ b/library/src/Nucleus/FileSystem/setFileContentsInterface.h
@@ -8,12 +8,13 @@
 #include <stdlib.h>
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
+#include "Nucleus/Types/Size.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_setFileContents.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_setFileContents.md
 Nucleus_NonNull(1, 2) Nucleus_Status
 Nucleus_setFileContents
     (
         Nucleus_InputParameter(const char *pathname),
         Nucleus_InputParameter(const char *bytes),
-        Nucleus_InputParameter(size_t numberOfBytes)
+        Nucleus_InputParameter(Nucleus_Size numberOfBytes)
     );

--- a/library/src/Nucleus/FileSystem/setFileContentsLinux.c
+++ b/library/src/Nucleus/FileSystem/setFileContentsLinux.c
@@ -29,7 +29,7 @@ Nucleus_setFileContents
     (
         Nucleus_InputParameter(const char *pathname),
         Nucleus_InputParameter(const char *bytes),
-        Nucleus_InputParameter(size_t numberOfBytes)
+        Nucleus_InputParameter(Nucleus_Size numberOfBytes)
     )
 {
     Nucleus_Status status;

--- a/library/src/Nucleus/FileSystem/setFileContentsWindows.c
+++ b/library/src/Nucleus/FileSystem/setFileContentsWindows.c
@@ -18,7 +18,7 @@ Nucleus_setFileContents
     (
         Nucleus_InputParameter(const char *pathname),
         Nucleus_InputParameter(const char *bytes),
-        Nucleus_InputParameter(size_t numberOfBytes)
+        Nucleus_InputParameter(Nucleus_Size numberOfBytes)
     )
 {
     if (!pathname || !bytes)

--- a/library/src/Nucleus/FloatingPoint.h
+++ b/library/src/Nucleus/FloatingPoint.h
@@ -7,9 +7,9 @@
 
 
 
-#include <stdbool.h>
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
+#include "Nucleus/Types/Boolean.h"
 
 
 
@@ -35,53 +35,53 @@ typedef long double Nucleus_Quadruple;
 
 
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[Floating-Point-Type]_isSubnormal.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[Floating-Point-Type]_isSubnormal.md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_Single_isSubnormal
     (
         Nucleus_Single x,
-        bool *r
+        Nucleus_Boolean *r
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[Floating-Point-Type]_isSubnormal.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[Floating-Point-Type]_isSubnormal.md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_Double_isSubnormal
     (
         Nucleus_Double x,
-        bool *r
+        Nucleus_Boolean *r
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[Floating-Point-Type]_isSubnormal.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[Floating-Point-Type]_isSubnormal.md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_Quadruple_isSubnormal
     (
         Nucleus_Quadruple x,
-        bool *r
+        Nucleus_Boolean *r
     );
 
 
 
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[Floating-Point-Type]_isNaN.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[Floating-Point-Type]_isNaN.md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_Single_isNaN
     (
         Nucleus_Single x,
-        bool *r
+        Nucleus_Boolean *r
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[Floating-Point-Type]_isNaN.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[Floating-Point-Type]_isNaN.md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_Double_isNaN
     (
         Nucleus_Double x,
-        bool *r
+        Nucleus_Boolean *r
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[Floating-Point-Type]_isNaN.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[Floating-Point-Type]_isNaN.md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_Quadruple_isNaN
     (
         Nucleus_Quadruple x,
-        bool *r
+        Nucleus_Boolean *r
     );

--- a/library/src/Nucleus/Hash/Boolean.h
+++ b/library/src/Nucleus/Hash/Boolean.h
@@ -6,7 +6,7 @@
 #include "Nucleus/Types/HashValue.h"
 #include "Nucleus/Types/Boolean.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hashBoolean.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hashBoolean.md
 Nucleus_NoError() Nucleus_Status
 Nucleus_hashBoolean
     (

--- a/library/src/Nucleus/Hash/FloatingPoint.h
+++ b/library/src/Nucleus/Hash/FloatingPoint.h
@@ -6,7 +6,7 @@
 #include "Nucleus/Types/HashValue.h"
 #include "Nucleus/Types/FloatingPoint.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumericType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumericType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashSingle
     (
@@ -14,7 +14,7 @@ Nucleus_hashSingle
         Nucleus_HashValue *hv
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumericType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumericType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashDouble
     (
@@ -22,7 +22,7 @@ Nucleus_hashDouble
         Nucleus_HashValue *hv
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumericType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumericType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuadruple
     (

--- a/library/src/Nucleus/Hash/HashValue.h
+++ b/library/src/Nucleus/Hash/HashValue.h
@@ -5,7 +5,7 @@
 #include "Nucleus/Status.h"
 #include "Nucleus/Types/HashValue.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_Status
 Nucleus_hashHashValue
     (

--- a/library/src/Nucleus/Hash/Integer.c
+++ b/library/src/Nucleus/Hash/Integer.c
@@ -7,71 +7,71 @@
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger8
     (
-        const Nucleus_Integer8 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer8 value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Integer8), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Integer8), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger16
     (
-        const Nucleus_Integer16 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer16 value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Integer16), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Integer16), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger32
     (
-        const Nucleus_Integer32 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer32 value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Integer32), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Integer32), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger64
     (
-        const Nucleus_Integer64 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer64 value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Integer64), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Integer64), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuarterInteger
     (
-        const Nucleus_QuarterInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuarterInteger value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_QuarterInteger), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_QuarterInteger), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashHalfInteger
     (
-        const Nucleus_HalfInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_HalfInteger value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_HalfInteger), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_HalfInteger), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger
     (
-        const Nucleus_Integer v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Integer), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Integer), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashDoubleInteger
     (
-        const Nucleus_DoubleInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_DoubleInteger value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_DoubleInteger), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_DoubleInteger), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuadrupleInteger
     (
-        const Nucleus_QuadrupleInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuadrupleInteger value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_QuadrupleInteger), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_QuadrupleInteger), hashValue); }

--- a/library/src/Nucleus/Hash/Integer.h
+++ b/library/src/Nucleus/Hash/Integer.h
@@ -6,74 +6,74 @@
 #include "Nucleus/Types/HashValue.h"
 #include "Nucleus/Types/Integer.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger8
     (
-        const Nucleus_Integer8 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer8 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger16
     (
-        const Nucleus_Integer16 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer16 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger32
     (
-        const Nucleus_Integer32 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer32 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger64
     (
-        const Nucleus_Integer64 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer64 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuarterInteger
     (
-        const Nucleus_QuarterInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuarterInteger value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashHalfInteger
     (
-        const Nucleus_HalfInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_HalfInteger value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashInteger
     (
-        const Nucleus_Integer v,
-        Nucleus_HashValue *hv
+        const Nucleus_Integer value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashDoubleInteger
     (
-        const Nucleus_DoubleInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_DoubleInteger value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuadrupleInteger
     (
-        const Nucleus_QuadrupleInteger v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuadrupleInteger value,
+        Nucleus_HashValue *hashValue
     );

--- a/library/src/Nucleus/Hash/Natural.c
+++ b/library/src/Nucleus/Hash/Natural.c
@@ -7,83 +7,83 @@
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural8
     (
-        const Nucleus_Natural8 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural8 value,
+        Nucleus_HashValue *hashValue
     )
 {
-    if (!hv) return Nucleus_Status_InvalidArgument;
-    *hv = (Nucleus_HashValue)v;
+    if (Nucleus_Unlikely(!hashValue)) return Nucleus_Status_InvalidArgument;
+    *hashValue = (Nucleus_HashValue)value;
     return Nucleus_Status_Success;
 }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural16
     (
-        const Nucleus_Natural16 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural16 value,
+        Nucleus_HashValue *hashValue
     )
 {
-    if (!hv) return Nucleus_Status_InvalidArgument;
-    *hv = (Nucleus_HashValue)v;
+    if (Nucleus_Unlikely(!hashValue)) return Nucleus_Status_InvalidArgument;
+    *hashValue = (Nucleus_HashValue)value;
     return Nucleus_Status_Success;
 }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural32
     (
-        const Nucleus_Natural32 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural32 value,
+        Nucleus_HashValue *hashValue
     )
 {
-    if (!hv) return Nucleus_Status_InvalidArgument;
-    *hv = (Nucleus_HashValue)v;
+    if (Nucleus_Unlikely(!hashValue)) return Nucleus_Status_InvalidArgument;
+    *hashValue = (Nucleus_HashValue)value;
     return Nucleus_Status_Success;
 }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural64
     (
-        const Nucleus_Natural64 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural64 value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Natural64), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Natural64), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuarterNatural
     (
-        const Nucleus_QuarterNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuarterNatural value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_QuarterNatural), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_QuarterNatural), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashHalfNatural
     (
-        const Nucleus_HalfNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_HalfNatural value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_HalfNatural), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_HalfNatural), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural
     (
-        const Nucleus_Natural v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_Natural), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_Natural), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashDoubleNatural
     (
-        const Nucleus_DoubleNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_DoubleNatural value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_DoubleNatural), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_DoubleNatural), hashValue); }
 
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuadrupleNatural
     (
-        const Nucleus_QuadrupleNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuadrupleNatural value,
+        Nucleus_HashValue *hashValue
     )
-{ return Nucleus_hashMemory((void *)&v, sizeof(Nucleus_QuadrupleNatural), hv); }
+{ return Nucleus_hashMemory((void *)&value, sizeof(Nucleus_QuadrupleNatural), hashValue); }

--- a/library/src/Nucleus/Hash/Natural.h
+++ b/library/src/Nucleus/Hash/Natural.h
@@ -6,74 +6,74 @@
 #include "Nucleus/Types/HashValue.h"
 #include "Nucleus/Types/Natural.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural8
     (
-        const Nucleus_Natural8 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural8 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural16
     (
-        const Nucleus_Natural16 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural16 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural32
     (
-        const Nucleus_Natural32 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural32 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural64
     (
-        const Nucleus_Natural64 v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural64 value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuarterNatural
     (
-        const Nucleus_QuarterNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuarterNatural value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashHalfNatural
     (
-        const Nucleus_HalfNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_HalfNatural value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashNatural
     (
-        const Nucleus_Natural v,
-        Nucleus_HashValue *hv
+        const Nucleus_Natural value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashDoubleNatural
     (
-        const Nucleus_DoubleNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_DoubleNatural value,
+        Nucleus_HashValue *hashValue
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashQuadrupleNatural
     (
-        const Nucleus_QuadrupleNatural v,
-        Nucleus_HashValue *hv
+        const Nucleus_QuadrupleNatural value,
+        Nucleus_HashValue *hashValue
     );

--- a/library/src/Nucleus/Hash/Size.h
+++ b/library/src/Nucleus/Hash/Size.h
@@ -6,7 +6,7 @@
 #include "Nucleus/Types/HashValue.h"
 #include "Nucleus/Types/Size.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_hash[NumberType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_hash[NumberType].md
 Nucleus_NoError() Nucleus_NonNull() Nucleus_Status
 Nucleus_hashSize
     (

--- a/library/src/Nucleus/Memory.c
+++ b/library/src/Nucleus/Memory.c
@@ -36,7 +36,7 @@ Nucleus_allocateMemory
         Nucleus_Size n
     )
 {
-    if (!p) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(!p)) return Nucleus_Status_InvalidArgument;
     void *q = malloc(n > 0 ? n : 1);
     if (!q) return Nucleus_Status_AllocationFailed;
     *p = q;
@@ -50,9 +50,9 @@ Nucleus_reallocateMemory
         Nucleus_Size n
     )
 {
-    if (!p || !*p) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(!p || !*p)) return Nucleus_Status_InvalidArgument;
     void *q = realloc(*p, n > 0 ? n : 1);
-    if (!q) return Nucleus_Status_AllocationFailed;
+    if (Nucleus_Unlikely(!q)) return Nucleus_Status_AllocationFailed;
     *p = q;
     return Nucleus_Status_Success;
 }
@@ -67,7 +67,7 @@ Nucleus_allocateArrayMemory
 {
     Nucleus_Size k;
     Nucleus_Status status = Nucleus_safeMulSize(n, m, &k);
-    if (status) return status;
+    if (Nucleus_Unlikely(status)) return status;
     return Nucleus_allocateMemory(p, k);
 }
 
@@ -81,7 +81,7 @@ Nucleus_reallocateArrayMemory
 {
     Nucleus_Size k;
     Nucleus_Status status = Nucleus_safeMulSize(n, m, &k);
-    if (status) return status;
+    if (Nucleus_Unlikely(status)) return status;
     return Nucleus_reallocateMemory(p, k);
 }
 
@@ -102,7 +102,7 @@ Nucleus_fillMemory
         Nucleus_Size n
     )
 {
-    if (!p) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(!p)) return Nucleus_Status_InvalidArgument;
     memset(p, v, n);
     return Nucleus_Status_Success;
 }
@@ -118,7 +118,7 @@ Nucleus_fillArrayMemory
 {
     Nucleus_Size k;
     Nucleus_Status status = Nucleus_safeMulSize(n, m, &k);
-    if (status) return status;
+    if (Nucleus_Unlikely(status)) return status;
     return Nucleus_fillMemory(p, v, k);
 }
 
@@ -130,7 +130,7 @@ Nucleus_copyMemory
         Nucleus_Size n
     )
 {
-    if (!p || !q) return Nucleus_Status_InvalidArgument;
+    if (Nucleus_Unlikely(!p || !q)) return Nucleus_Status_InvalidArgument;
     if (n == 0) return Nucleus_Status_Success;
     if (overlapping(p, q, n))
     {
@@ -186,7 +186,7 @@ Nucleus_compareArrayMemory
 {
     Nucleus_Size k;
     Nucleus_Status status = Nucleus_safeMulSize(n, m, &k);
-    if (status) return status;
+    if (Nucleus_Unlikely(status)) return status;
     return Nucleus_compareMemory(p, q, k, r);
 }
 
@@ -200,7 +200,7 @@ Nucleus_cloneMemory
 {
     if (Nucleus_Unlikely(!p || !q)) return Nucleus_Status_InvalidArgument;
     Nucleus_Status status = Nucleus_allocateMemory(p, n);
-    if (status) return status;
+    if (Nucleus_Unlikely(status)) return status;
     memcpy(*p, q, n);
     return Nucleus_Status_Success;
 }
@@ -216,6 +216,6 @@ Nucleus_cloneArrayMemory
 {
     Nucleus_Size k;
     Nucleus_Status status = Nucleus_safeMulSize(n, m, &k);
-    if (status) return status;
+    if (Nucleus_Unlikely(status)) return status;
     return Nucleus_cloneMemory(p, q, k);
 }

--- a/library/src/Nucleus/Memory.h
+++ b/library/src/Nucleus/Memory.h
@@ -7,7 +7,7 @@
 #include "Nucleus/Types/HashValue.h"
 #include "Nucleus/Types/Size.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_allocateMemory.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_allocateMemory.md
 Nucleus_NoError() Nucleus_NonNull(1) Nucleus_Status
 Nucleus_allocateMemory
     (
@@ -15,7 +15,7 @@ Nucleus_allocateMemory
         Nucleus_Size n
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_reallocateMemory.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_reallocateMemory.md
 Nucleus_NoError() Nucleus_NonNull(1) Nucleus_Status
 Nucleus_reallocateMemory
     (
@@ -32,7 +32,7 @@ Nucleus_allocateArrayMemory
         Nucleus_Size m
     );
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_reallocateArrayMemory.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_reallocateArrayMemory.md
 Nucleus_NoError() Nucleus_NonNull(1) Nucleus_Status
 Nucleus_reallocateArrayMemory
     (

--- a/library/src/Nucleus/MemoryManagerInterface.h
+++ b/library/src/Nucleus/MemoryManagerInterface.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include <stddef.h>
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
+#include "Nucleus/Types/Size.h"
 
 
 /// @brief The opaque type of a "memory manager state".
@@ -34,7 +34,7 @@ Nucleus_MemoryManager_Allocate
         Nucleus_InputOutputParameter(Nucleus_MemoryManager_State *state),
         Nucleus_InputOutputParameter(Nucleus_MemoryManager_AllocationParameters *allocationParameters),
         Nucleus_OutputParameter(void **memoryBlock),
-        Nucleus_InputParameter(size_t numberOfBytes)
+        Nucleus_InputParameter(Nucleus_Size numberOfBytes)
     );
 
 /// @brief Type of a Nucleus "deallocate" function.

--- a/library/src/Nucleus/Types/FloatingPoint.h
+++ b/library/src/Nucleus/Types/FloatingPoint.h
@@ -7,109 +7,109 @@
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 typedef float Nucleus_Single;
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_Least (-FLT_MAX)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_Greatest (+FLT_MAX)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_NaN (NAN)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_PositiveInfinity (+INFINITY)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_NegativeInfinity (-INFINITY)
 
 #define Nucleus_Single_MaximumNumberOfDecimalDigits (FLT_DIG)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_GreatestExponentValueBase10 (FLT_MAX_10_EXP)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Single_LeastExponentValueBase10 (FLT_MIN_10_EXP)
 
 // All machines we're aware of define this to 2 except of IBM 360 and derivatives.
 #if defined(FLT_RADIX) && 2 == FLT_RADIX
-    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    // https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
     #define Nucleus_Single_GreatestExponentValueBase2 (FLT_MAX_EXP)
-    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    // https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
     #define Nucleus_Single_LeastExponentValueBase2 (FLT_MIN_EXP)
 #endif
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 typedef double Nucleus_Double;
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_Least (-DBL_MAX)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_Greatest (+DBL_MAX)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_NaN (NAN)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_PositiveInfinity (+INFINITY)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_NegativeInfinity (-INFINITY)
 
 #define Nucleus_Double_MaximumNumberOfDecimalDigits (DBL_DIG)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_GreatestExponentValueBase10 (DBL_MAX_10_EXP)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Double_LeastExponentValueBase10 (DBL_MIN_10_EXP)
 
 // All machines we're aware of define this to 2 except of IBM 360 and derivatives.
 #if defined(FLT_RADIX) && 2 == FLT_RADIX
-    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    // https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
     #define Nucleus_Double_GreatestExponentValueBase2 (DBL_MAX_EXP)
-    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    // https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
     #define Nucleus_Double_LeastExponentValueBase2 (DBL_MIN_EXP)
 #endif
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 typedef long double Nucleus_Quadruple;
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_Least (-LDBL_MAX)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_Greatest (+LDBL_MAX)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_NaN (NAN)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_PositiveInfinity (+INFINITY)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_NegativeInfinity (-INFINITY)
 
 #define Nucleus_Quadruple_MaximumNumberOfDecimalDigits (LDBL_DIG)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_GreatestExponentValueBase10 (LDBL_MAX_10_EXP)
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
 #define Nucleus_Quadruple_LeastExponentValueBase10 (LDBL_MIN_10_EXP)
 
 // All machines we're aware of define this to 2 except of IBM 360 and derivatives.
 #if defined(FLT_RADIX) && 2 == FLT_RADIX
-    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    // https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
     #define Nucleus_Quadruple_GreatestExponentValueBase2 (LDBL_MAX_EXP)
-    // https://github.com/primordialmachine/blob/master/documentation/Nucleus_[FloatingPointType].md
+    // https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_[FloatingPointType].md
     #define Nucleus_Quadruple_LeastExponentValueBase2 (LDBL_MIN_EXP)
 #endif
 

--- a/library/src/Nucleus/getExecutableDirectoryPathname.h
+++ b/library/src/Nucleus/getExecutableDirectoryPathname.h
@@ -4,7 +4,7 @@
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_getExecutableDirectoryPathname.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_getExecutableDirectoryPathname.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_getExecutableDirectoryPathname
     (

--- a/library/src/Nucleus/getExecutablePathname.h
+++ b/library/src/Nucleus/getExecutablePathname.h
@@ -4,7 +4,7 @@
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_getExecutablePathname.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_getExecutablePathname.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_getExecutablePathname
     (

--- a/library/src/Nucleus/getExecutablePathnameLinux.h
+++ b/library/src/Nucleus/getExecutablePathnameLinux.h
@@ -9,7 +9,7 @@
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_getExecutablePathname.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_getExecutablePathname.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_getExecutablePathnameLinux
     (

--- a/library/src/Nucleus/getExecutablePathnameMacOS.c
+++ b/library/src/Nucleus/getExecutablePathnameMacOS.c
@@ -43,7 +43,7 @@ Nucleus_getExecutablePathnameMacOS
         {
             break;
         }
-        status = Nucleus_reallocateMemory((void **)&buffer, (size_t)size);
+        status = Nucleus_reallocateMemory((void **)&buffer, (Nucleus_Size)size);
         if (Nucleus_Unlikely(status))
         {
             ERROR(stderr, "%s:%d: %s failed\n", __FILE__, __LINE__, "Nucleus_reallocateMemory");

--- a/library/src/Nucleus/getExecutablePathnameMacOS.h
+++ b/library/src/Nucleus/getExecutablePathnameMacOS.h
@@ -8,7 +8,7 @@
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_getExecutablePathname.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_getExecutablePathname.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_getExecutablePathnameMacOS
     (

--- a/library/src/Nucleus/getExecutablePathnameWindows.h
+++ b/library/src/Nucleus/getExecutablePathnameWindows.h
@@ -8,7 +8,7 @@
 #include "Nucleus/Annotations.h"
 #include "Nucleus/Status.h"
 
-// https://github.com/primordialmachine/blob/master/documentation/Nucleus_getExecutablePathname.md
+// https://github.com/primordialmachine/nucleus/blob/master/documentation/Nucleus_getExecutablePathname.md
 Nucleus_NonNull() Nucleus_Status
 Nucleus_getExecutablePathnameWindows
     (


### PR DESCRIPTION
- Add function annotations Nucleus_Always(Succeed|Fail).
- Fix comments.
- Use (Nucleus_Size|Nucleus_Boolean|Nucleus_HashValue) where
  appropriate.
- Add missing Nucleus_Status return value to functions.
- Apply annotations Nucleus_(Likely|Unlikely) to expressions.