### PR TITLE
Update Nucleus

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,8 +1,18 @@
 # Copyright (c) 2017, 2018 Michael Heilmann
 # Assert minimum CMake version.
 cmake_minimum_required(VERSION 3.8)
-# Define the static library.
-define_static_library(Nucleus Nucleus.Library ${NUCLEUS_LANGUAGE_ID_C})
+# Define the library.
+# Default to "static" (as opposed to "shared") variant.
+if (NOT DEFINED Nucleus.Library-Shared)
+  set(Nucleus.Library-Shared OFF)
+endif()
+if (Nucleus.Library-Shared)
+  # Define the shared library.
+  define_shared_library(Nucleus Nucleus.Library ${NUCLEUS_LANGUAGE_ID_C})
+else()
+  # Define the static library.
+  define_static_library(Nucleus Nucleus.Library ${NUCLEUS_LANGUAGE_ID_C})
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/buildsystem/Configuration.h.i
                ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Configuration.h.i)
@@ -25,3 +35,8 @@ endif()
 
 # Link to the selected threading libraries.
 target_link_libraries(Nucleus.Library PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+
+if (Nucleus.Library-Shared)
+  set_target_properties(Nucleus.Library PROPERTIES
+                        COMPILE_FLAGS -DNUCLEUS_LIBRARY_STATIC_DEFINE)
+endif()


### PR DESCRIPTION
- Remove Doxygen-related code from CMake build system.
- Add "shared" library template (as opposed to "dynamically
  loadable" library and "static" library).
- Add Nucleus.Library-Shared option to build the Nucleus library
  as a "shared" library.